### PR TITLE
fixed typo preventing line from being hidden on mobile

### DIFF
--- a/packages/vanilla-components-grapesjs/src/components.js
+++ b/packages/vanilla-components-grapesjs/src/components.js
@@ -534,7 +534,7 @@ export default (editor, config = {}) => {
                 {
                   'properties': {
                     'sharemedium': { 'enum': ['line'] },
-                    'linetdisplayrule': displayRuleObj.mobile,
+                    'linedisplayrule': displayRuleObj.mobile,
                     'linetext': shareMediumTextObj,
                     'linetextcolor': shareMediumTextColorObj,
                     'linebackgroundcolor': shareMediumColorObj


### PR DESCRIPTION
note the typo; couldn't hide Line Messenger share button on mobile using widget editor.