### PR TITLE
DEV-2801 Updating Sharelink() query to use clean share link for copy link button

### DIFF
--- a/packages/vanilla-components/package-lock.json
+++ b/packages/vanilla-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/vanilla-components",
-  "version": "1.0.13-0",
+  "version": "1.0.13-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/vanilla-components/package-lock.json
+++ b/packages/vanilla-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/vanilla-components",
-  "version": "1.0.12",
+  "version": "1.0.13-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/vanilla-components/package-lock.json
+++ b/packages/vanilla-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/vanilla-components",
-  "version": "1.0.13-1",
+  "version": "1.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/vanilla-components/package.json
+++ b/packages/vanilla-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/vanilla-components",
-  "version": "1.0.12",
+  "version": "1.0.13-0",
   "description": "Vanilla component library for the SaaSquatch platform",
   "main": "dist/index.js",
   "types": "dist/types/components.d.ts",

--- a/packages/vanilla-components/package.json
+++ b/packages/vanilla-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/vanilla-components",
-  "version": "1.0.13-1",
+  "version": "1.0.13",
   "description": "Vanilla component library for the SaaSquatch platform",
   "main": "dist/index.js",
   "types": "dist/types/components.d.ts",

--- a/packages/vanilla-components/package.json
+++ b/packages/vanilla-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/vanilla-components",
-  "version": "1.0.13-0",
+  "version": "1.0.13-1",
   "description": "Vanilla component library for the SaaSquatch platform",
   "main": "dist/index.js",
   "types": "dist/types/components.d.ts",

--- a/packages/vanilla-components/src/services/WidgetHost.ts
+++ b/packages/vanilla-components/src/services/WidgetHost.ts
@@ -254,7 +254,7 @@ const API = {
         query: gql`
           query($userId: String!, $accountId: String!, $programId: ID, $engagementMedium: UserEngagementMedium!) {
             user(id: $userId, accountId: $accountId) {
-              shareLink(programId: $programId, engagementMedium: $engagementMedium, shareMedium: DIRECT)
+              shareLink(programId: $programId, engagementMedium: $engagementMedium, shareMedium: DIRECT, useCleanLink: true)
             }
           }
         `,


### PR DESCRIPTION
## Description of the change

Updating the sharelink() query that the copy link button uses to get its share link. Originally, this query would get the UNKNOWN DIRECT sharelink. Now if the user has a custom sharelink, it will return the clean share link (unencoded) but if the user has an auto-generated share link, it will still return the UNKNOWN DIRECT as before.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

 - Jira issue number: ji2801
 - Process.st launch checklist: https://app.process.st/checklists/Vanity-Links-and-Codes-m2vL63FIM9e3QB_sN5JIAQ/tasks/onlBImyM_Q-rfZjJGw9HwA

## Checklists

### Development

- [ ] [Prettier](https://www.npmjs.com/package/prettier) was run
- [ ] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist
- [ ] "Ready for review" label attached to the PR and reviewers pinged on Slack

### Code review 

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
