### PR TITLE
DEV-2791: yarn does not need to be a dependency in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6917,11 +6917,6 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
-    },
-    "yarn": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.7.0.tgz",
-      "integrity": "sha1-AHa5/eYBDgGVBSamCbxTvBde+SU="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,8 +18,5 @@
   "homepage": "https://github.com/saasquatch/program-tools#readme",
   "devDependencies": {
     "lerna": "^3.22.1"
-  },
-  "dependencies": {
-    "yarn": "^1.7.0"
   }
 }


### PR DESCRIPTION
## Description of the change

yarn does not need to be a dependency in package.json

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

 - Jira issue number: DEV-2791
 - Process.st launch checklist: (PUT IT HERE)

## Checklists

### Development

- [ ] [Prettier](https://www.npmjs.com/package/prettier) was run
- [ ] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist
- [x] "Ready for review" label attached to the PR and reviewers pinged on Slack

### Code review 

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
