### PR TITLE
Add isValidBasicExpression checking to the JSONata editor

### DIFF
--- a/packages/visual-dev/package-lock.json
+++ b/packages/visual-dev/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/visual-dev",
-  "version": "0.0.2-21",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/visual-dev/package.json
+++ b/packages/visual-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/visual-dev",
-  "version": "0.0.2-21",
+  "version": "0.1.1",
   "description": "SaaSquatch visual dev",
   "main": "build/index.js",
   "module": "build/index.es.js",

--- a/packages/visual-dev/src/components/JSONata/PathEditor.tsx
+++ b/packages/visual-dev/src/components/JSONata/PathEditor.tsx
@@ -98,6 +98,7 @@ type PathEditorProps = {
   onChange: (ast: Option) => void;
   value: AST;
   schemaProvider?: SchemaProvider;
+  hideArrow?: boolean;
 };
 
 export function Reducer(acc: Option[], p: PathSuggestion): Option[] {
@@ -153,7 +154,7 @@ export default function PathEditor(props: PathEditorProps) {
           e.preventDefault();
         }}
         clearable={false}
-        arrowRenderer={ArrowRenderer}
+        arrowRenderer={props?.hideArrow ? () => {return <></>} : ArrowRenderer}
         onNewOptionClick={handleCreate}
         defaultOptions
         options={schemaOptions}

--- a/packages/visual-dev/src/components/JSONata/PathEditor.tsx
+++ b/packages/visual-dev/src/components/JSONata/PathEditor.tsx
@@ -25,17 +25,18 @@ const StyledOption = styled.div`
 `;
 
 type AST = JsonataASTNode;
-type Option = {
-  type: "suggested";
-  label: string;
-  value: AST;
-  data: PathSuggestion;
-}
+type Option =
   | {
-    type: "created";
-    label: string;
-    value: AST;
-  };
+      type: "suggested";
+      label: string;
+      value: AST;
+      data: PathSuggestion;
+    }
+  | {
+      type: "created";
+      label: string;
+      value: AST;
+    };
 
 //@ts-ignore
 type CustomOptionProps = React.ComponentProps<typeof defaultComponents.Option>;
@@ -143,9 +144,9 @@ export default function PathEditor(props: PathEditorProps) {
   const option = foundOption
     ? foundOption
     : {
-      label: stringValue,
-      value: props.value,
-    };
+        label: stringValue,
+        value: props.value,
+      };
 
   return (
     <div>
@@ -154,7 +155,13 @@ export default function PathEditor(props: PathEditorProps) {
           e.preventDefault();
         }}
         clearable={false}
-        arrowRenderer={props?.hideArrow ? () => {return <></>} : ArrowRenderer}
+        arrowRenderer={
+          props?.hideArrow
+            ? () => {
+                return <></>;
+              }
+            : ArrowRenderer
+        }
         onNewOptionClick={handleCreate}
         defaultOptions
         options={schemaOptions}

--- a/packages/visual-dev/src/components/MapFieldsJsonata.tsx
+++ b/packages/visual-dev/src/components/MapFieldsJsonata.tsx
@@ -91,8 +91,18 @@ type AddRemoveGroupProps = {
   canDelete?: boolean;
 };
 
+function isValidBasicExpression(newValue: AST): string | null {
+  const advancedOnly = jsonata(`**[type = "function" or type = "lambda" or (type = "binary" and value = "&")]`);
+  try {
+    if(advancedOnly.evaluate(newValue)) {
+      return "Can't use basic editor for advanced expressions. Try a simpler expression."
+    } 
+  } catch (e) {}
+  return null;
+}
+
 function JSONataEditorView(props: JSONataEditorViewProps) {
-  const { showButton, loading, defaultValue, singleRowArray } = props.states;
+  const { showButton, loading, defaultValue, singleRowArray, hideArrow } = props.states;
   const { value, inputDataSchema, keyTitle, valueTitle, addButtonText, addButtonTextEmpty, defaultObject } = props.data;
   const { onChange } = props.callbacks;
 
@@ -476,6 +486,7 @@ function JSONataEditorView(props: JSONataEditorViewProps) {
         )}
         <SmallPickerWrapper>
           <PathPicker
+            hideArrow={hideArrow}
             value={ast}
             onChange={(option) => onChange(option.value as AST)}
             schemaProvider={newSchemaProvider}
@@ -547,7 +558,7 @@ function JSONataEditorView(props: JSONataEditorViewProps) {
       <Editor
         text={value || defaultValue}
         onChange={onChange}
-        // isValidBasicExpression={JSONataUtils.isValidBasicExpression}
+        isValidBasicExpression={isValidBasicExpression}
         theme={{
           ...SaasquatchTheme,
           ...FormEditorTheme,
@@ -585,6 +596,7 @@ type JSONataEditorHookProps = {
     addButtonText?: string;
     addButtonTextEmpty?: string;
     defaultObject?: object;
+    hideArrow?: boolean;
   };
   onChange: (value: string) => void;
 };
@@ -600,6 +612,7 @@ const JSONataEditor: React.FC<JSONataEditorHookProps> = (props) => {
   const addButtonText = props?.options?.addButtonText || "+ Add Field";
   const addButtonTextEmpty = props?.options?.addButtonTextEmpty || "+ Add Field(s)";
   const defaultObject = props?.options?.defaultObject;
+  const hideArrow = props?.options?.hideArrow;
 
   const loading = false;
   const showButton =
@@ -614,6 +627,7 @@ const JSONataEditor: React.FC<JSONataEditorHookProps> = (props) => {
       loading,
       defaultValue,
       singleRowArray,
+      hideArrow,
     },
     data: {
       value,
@@ -641,6 +655,7 @@ type JSONataEditorHookStates = {
   loading: boolean;
   defaultValue: string;
   singleRowArray?: boolean;
+  hideArrow?: boolean;
 };
 
 type JSONataEditorHookData = {

--- a/packages/visual-dev/src/components/MapFieldsJsonata.tsx
+++ b/packages/visual-dev/src/components/MapFieldsJsonata.tsx
@@ -1,5 +1,10 @@
 import jsonata from "jsonata";
-import { serializer, ConditionNode, ObjectUnaryNode, JsonataASTNode } from "jsonata-ui-core";
+import {
+  serializer,
+  ConditionNode,
+  ObjectUnaryNode,
+  JsonataASTNode,
+} from "jsonata-ui-core";
 import {
   ConditionEditorProps,
   Editor,
@@ -92,23 +97,37 @@ type AddRemoveGroupProps = {
 };
 
 function isValidBasicExpression(newValue: AST): string | null {
-  const advancedOnly = jsonata(`**[type = "function" or type = "lambda" or (type = "binary" and value = "&")]`);
+  const advancedOnly = jsonata(
+    `**[type = "function" or type = "lambda" or (type = "binary" and value = "&")]`
+  );
   try {
-    if(advancedOnly.evaluate(newValue)) {
-      return "Can't use basic editor for advanced expressions. Try a simpler expression."
-    } 
+    if (advancedOnly.evaluate(newValue)) {
+      return "Can't use basic editor for advanced expressions. Try a simpler expression.";
+    }
   } catch (e) {}
   return null;
 }
 
 function JSONataEditorView(props: JSONataEditorViewProps) {
-  const { showButton, loading, defaultValue, singleRowArray, hideArrow } = props.states;
-  const { value, inputDataSchema, keyTitle, valueTitle, addButtonText, addButtonTextEmpty, defaultObject } = props.data;
+  const {
+    showButton,
+    loading,
+    defaultValue,
+    singleRowArray,
+    hideArrow,
+  } = props.states;
+  const {
+    value,
+    inputDataSchema,
+    keyTitle,
+    valueTitle,
+    addButtonText,
+    addButtonTextEmpty,
+    defaultObject,
+  } = props.data;
   const { onChange } = props.callbacks;
 
-  function AddRemoveGroup({
-    addNew,
-  }: AddRemoveGroupProps) {
+  function AddRemoveGroup({ addNew }: AddRemoveGroupProps) {
     return (
       <>
         <FormButton
@@ -127,16 +146,18 @@ function JSONataEditorView(props: JSONataEditorViewProps) {
     ast: ObjectUnaryNode,
     onChange: OnChange<JsonataASTNode>
   ) {
-    const newExpression = defaultObject ? defaultObject : [
-      {
-        value: "",
-        type: "string",
-      },
-      {
-        type:"path",
-        steps: [{type:"name",value:"select"}]
-      },
-    ];
+    const newExpression = defaultObject
+      ? defaultObject
+      : [
+          {
+            value: "",
+            type: "string",
+          },
+          {
+            type: "path",
+            steps: [{ type: "name", value: "select" }],
+          },
+        ];
     onChange({
       ...ast,
       lhs: [...ast.lhs, newExpression],
@@ -257,14 +278,10 @@ function JSONataEditorView(props: JSONataEditorViewProps) {
           <thead>
             <tr>
               <THead>
-                <H3>
-                  {keyTitle}
-                </H3>
+                <H3>{keyTitle}</H3>
               </THead>
               <THead>
-                <H3>
-                  {valueTitle}
-                </H3>
+                <H3>{valueTitle}</H3>
               </THead>
               <THead />
             </tr>
@@ -470,15 +487,13 @@ function JSONataEditorView(props: JSONataEditorViewProps) {
   };
 
   function PathEditor(props: PathEditorProps) {
-    const { ast, onChange } = props
+    const { ast, onChange } = props;
     const newSchemaProvider = SchemaProvider.makeSchemaProvider(
       inputDataSchema
     );
     const renderTypeSwitch = false;
     const changeType = () => onChange(nextAst(ast, defaultPath()));
-    
-    
-      
+
     return (
       <div style={{ display: "flex", flexDirection: "row" }}>
         {renderTypeSwitch && (
@@ -610,7 +625,8 @@ const JSONataEditor: React.FC<JSONataEditorHookProps> = (props) => {
   const keyTitle = props?.options?.keyTitle || "Key";
   const value = props.value || initialValue;
   const addButtonText = props?.options?.addButtonText || "+ Add Field";
-  const addButtonTextEmpty = props?.options?.addButtonTextEmpty || "+ Add Field(s)";
+  const addButtonTextEmpty =
+    props?.options?.addButtonTextEmpty || "+ Add Field(s)";
   const defaultObject = props?.options?.defaultObject;
   const hideArrow = props?.options?.hideArrow;
 

--- a/packages/visual-dev/src/components/stories/RJSF.stories.tsx
+++ b/packages/visual-dev/src/components/stories/RJSF.stories.tsx
@@ -201,26 +201,12 @@ const uiSchema = {
       fieldMapExpr: {
         "ui:widget": JSONataEditor,
         "ui:options": {
-          defaultValue: `{
-            "DEFAULT VALUE":SELECT123
+          hideArrow: true,
+          initialValue: `{
+            "":\`Enter a value\`
           }`,
-          // defaultObject: [
-          //   {
-          //     value: "DEFAULT OBJECT",
-          //     type: "string",
-          //   },
-          //   {
-          //     type: "path",
-          //     steps: [{ type: "name", value: "SELECTOR" }],
-          //   },
-          // ],
-        },
-      },
-      filterExpr: {
-        "ui:widget": JSONataEditor,
-        "ui:options": {
           defaultValue: `{
-            "TEST":SELECTOR
+            "":\`Enter a value\`
           }`,
           defaultObject: [
             {
@@ -229,7 +215,25 @@ const uiSchema = {
             },
             {
               type: "path",
-              steps: [{ type: "name", value: "select" }],
+              steps: [{ type: "name", value: "Enter a value" }],
+            },
+          ],
+        },
+      },
+      filterExpr: {
+        "ui:widget": JSONataEditor,
+        "ui:options": {
+          defaultValue: `{
+            "":\`Enter a value\`
+          }`,
+          defaultObject: [
+            {
+              value: "",
+              type: "string",
+            },
+            {
+              type: "path",
+              steps: [{ type: "name", value: "Enter a value" }],
             },
           ],
         },


### PR DESCRIPTION
## Description of the change

Update the JSONata editor to with a patched version of `isValidBasicExpression`. This prevents the user from switching to the basic JSONata editor when they have entered an unsupported JSONata expression in the advanced editor.

Additionally, added a prop to optionally hide arrows from selectors in the JSONata editor.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

 - Jira issue number: (PUT IT HERE)
 - Process.st launch checklist: (PUT IT HERE)

## Checklists

### Development

- [x] [Prettier](https://www.npmjs.com/package/prettier) was run
- [ ] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist
- [ ] "Ready for review" label attached to the PR and reviewers pinged on Slack

### Code review 

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
