### PR TITLE
DEV-2932: Fix rewardId in email mutation and allow null analytics dedupeIds

### DIFF
--- a/packages/program-boilerplate/package-lock.json
+++ b/packages/program-boilerplate/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.5-7",
+  "version": "3.5.5-8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/program-boilerplate/package-lock.json
+++ b/packages/program-boilerplate/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.5-8",
+  "version": "3.5.5-9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/program-boilerplate/package-lock.json
+++ b/packages/program-boilerplate/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.5-9",
+  "version": "3.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/program-boilerplate/package-lock.json
+++ b/packages/program-boilerplate/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.5-0",
+  "version": "3.5.5-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/program-boilerplate/package-lock.json
+++ b/packages/program-boilerplate/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.5-6",
+  "version": "3.5.5-7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/program-boilerplate/package-lock.json
+++ b/packages/program-boilerplate/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.5-2",
+  "version": "3.5.5-3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/program-boilerplate/package-lock.json
+++ b/packages/program-boilerplate/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.5-4",
+  "version": "3.5.5-5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/program-boilerplate/package-lock.json
+++ b/packages/program-boilerplate/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.5-3",
+  "version": "3.5.5-4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/program-boilerplate/package-lock.json
+++ b/packages/program-boilerplate/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.5-1",
+  "version": "3.5.5-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/program-boilerplate/package-lock.json
+++ b/packages/program-boilerplate/package-lock.json
@@ -1,18 +1,9 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.4",
+  "version": "3.5.5-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-      "dev": true,
-      "requires": {
-        "@babel/highlight": "^7.10.4"
-      }
-    },
     "@babel/helper-validator-identifier": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
@@ -36,7 +27,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -45,9 +36,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "color-convert": {
@@ -83,9 +74,18 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
       }
     },
     "@dabh/diagnostics": {
@@ -104,7 +104,7 @@
       "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
       "dev": true,
       "requires": {
-        "any-observable": "0.3.0"
+        "any-observable": "^0.3.0"
       },
       "dependencies": {
         "any-observable": {
@@ -136,8 +136,16 @@
       "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
       "dev": true,
       "requires": {
-        "@types/connect": "3.4.33",
-        "@types/node": "13.13.4"
+        "@types/connect": "*",
+        "@types/node": "*"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
+          "integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==",
+          "dev": true
+        }
       }
     },
     "@types/cacheable-request": {
@@ -164,8 +172,22 @@
       "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
       "dev": true,
       "requires": {
-        "@types/node": "13.13.4"
+        "@types/node": "*"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
+          "integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==",
+          "dev": true
+        }
       }
+    },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
     },
     "@types/express": {
       "version": "4.17.7",
@@ -173,31 +195,38 @@
       "integrity": "sha512-dCOT5lcmV/uC2J9k0rPafATeeyz+99xTt54ReX11/LObZgfzJqZNcW27zGhYyX+9iSEGXGt5qLPwRSvBZcLvtQ==",
       "dev": true,
       "requires": {
-        "@types/body-parser": "1.19.0",
-        "@types/express-serve-static-core": "4.17.5",
-        "@types/qs": "6.9.1",
-        "@types/serve-static": "1.13.3"
-      }
-    },
-    "@types/express-serve-static-core": {
-      "version": "4.17.8",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.8.tgz",
-      "integrity": "sha512-1SJZ+R3Q/7mLkOD9ewCBDYD2k0WyZQtWYqF/2VvoNN2/uhI49J9CDN4OAm+wGMA0DbArA4ef27xl4+JwMtGggw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
         "@types/qs": "*",
-        "@types/range-parser": "*"
-      }
-    },
-    "@types/glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
-      "dev": true,
-      "requires": {
-        "@types/minimatch": "*",
-        "@types/node": "*"
+        "@types/serve-static": "*"
+      },
+      "dependencies": {
+        "@types/express-serve-static-core": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.5.tgz",
+          "integrity": "sha512-578YH5Lt88AKoADy0b2jQGwJtrBxezXtVe/MBqWXKZpqx91SnC0pVkVCcxcytz3lWW+cHBYDi3Ysh0WXc+rAYw==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "@types/range-parser": "*"
+          }
+        },
+        "@types/qs": {
+          "version": "6.9.1",
+          "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.1.tgz",
+          "integrity": "sha512-lhbQXx9HKZAPgBkISrBcmAcMpZsmpe/Cd/hY7LGZS5OfkySUBItnPZHgQPssWYUET8elF+yCFBbP1Q0RZPTdaw==",
+          "dev": true
+        },
+        "@types/serve-static": {
+          "version": "1.13.3",
+          "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
+          "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
+          "dev": true,
+          "requires": {
+            "@types/express-serve-static-core": "*",
+            "@types/mime": "*"
+          }
+        }
       }
     },
     "@types/http-cache-semantics": {
@@ -251,12 +280,6 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
-    "@types/qs": {
-      "version": "6.9.3",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.3.tgz",
-      "integrity": "sha512-7s9EQWupR1fTc2pSMtXRQ9w9gLOcrJn+h7HOXw4evxyvVqMi4f+q7d2tnFe3ng3SNHjtK+0EzGMGFUQX4/AQRA==",
-      "dev": true
-    },
     "@types/range-parser": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
@@ -272,22 +295,12 @@
         "@types/node": "*"
       }
     },
-    "@types/serve-static": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.4.tgz",
-      "integrity": "sha512-jTDt0o/YbpNwZbQmE/+2e+lfjJEJJR0I3OFaKQKPWkASkCoW3i6fsUnqudSMcNAfbtmADGu8f4MV4q+GqULmug==",
-      "dev": true,
-      "requires": {
-        "@types/express-serve-static-core": "4.17.5",
-        "@types/mime": "2.0.1"
-      }
-    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
       "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
       "requires": {
-        "mime-types": "2.1.27",
+        "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
       }
     },
@@ -315,7 +328,7 @@
       "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
       "dev": true,
       "requires": {
-        "string-width": "3.1.0"
+        "string-width": "^3.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -342,9 +355,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
@@ -353,7 +366,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -364,7 +377,7 @@
       "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
       "dev": true,
       "requires": {
-        "type-fest": "0.11.0"
+        "type-fest": "^0.11.0"
       }
     },
     "ansi-regex": {
@@ -400,7 +413,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -438,15 +451,15 @@
       "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
       "requires": {
         "bytes": "3.1.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "http-errors": "1.7.2",
         "iconv-lite": "0.4.24",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.7.0",
         "raw-body": "2.4.0",
-        "type-is": "1.6.18"
+        "type-is": "~1.6.17"
       }
     },
     "boxen": {
@@ -455,14 +468,14 @@
       "integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
       "dev": true,
       "requires": {
-        "ansi-align": "3.0.0",
-        "camelcase": "5.3.1",
-        "chalk": "3.0.0",
-        "cli-boxes": "2.2.0",
-        "string-width": "4.2.0",
-        "term-size": "2.2.0",
-        "type-fest": "0.8.1",
-        "widest-line": "3.1.0"
+        "ansi-align": "^3.0.0",
+        "camelcase": "^5.3.1",
+        "chalk": "^3.0.0",
+        "cli-boxes": "^2.2.0",
+        "string-width": "^4.1.0",
+        "term-size": "^2.1.0",
+        "type-fest": "^0.8.1",
+        "widest-line": "^3.1.0"
       },
       "dependencies": {
         "type-fest": {
@@ -479,7 +492,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -542,9 +555,9 @@
       "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
       "dev": true,
       "requires": {
-        "camelcase": "5.3.1",
-        "map-obj": "4.1.0",
-        "quick-lru": "4.0.1"
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
       }
     },
     "chalk": {
@@ -553,8 +566,8 @@
       "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
       "dev": true,
       "requires": {
-        "ansi-styles": "4.2.1",
-        "supports-color": "7.1.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       }
     },
     "chardet": {
@@ -587,7 +600,7 @@
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "requires": {
-        "restore-cursor": "3.1.0"
+        "restore-cursor": "^3.1.0"
       }
     },
     "cli-truncate": {
@@ -597,7 +610,7 @@
       "dev": true,
       "requires": {
         "slice-ansi": "0.0.4",
-        "string-width": "1.0.2"
+        "string-width": "^1.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -612,7 +625,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -621,9 +634,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-ansi": {
@@ -632,7 +645,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -702,15 +715,23 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "color-string": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
       "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
       "requires": {
-        "color-name": "1.1.3",
-        "simple-swizzle": "0.2.2"
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      },
+      "dependencies": {
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        }
       }
     },
     "colors": {
@@ -723,16 +744,23 @@
       "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
       "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
       "requires": {
-        "color": "3.0.0",
-        "text-hex": "1.0.0"
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
       }
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "optional": true
     },
     "compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
       "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
       "requires": {
-        "mime-db": "1.44.0"
+        "mime-db": ">= 1.43.0 < 2"
       }
     },
     "compression": {
@@ -740,13 +768,13 @@
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
       "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
       "requires": {
-        "accepts": "1.3.7",
+        "accepts": "~1.3.5",
         "bytes": "3.0.0",
-        "compressible": "2.0.18",
+        "compressible": "~2.0.16",
         "debug": "2.6.9",
-        "on-headers": "1.0.2",
+        "on-headers": "~1.0.2",
         "safe-buffer": "5.1.2",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "bytes": {
@@ -768,12 +796,12 @@
       "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
       "dev": true,
       "requires": {
-        "dot-prop": "5.2.0",
-        "graceful-fs": "4.2.4",
-        "make-dir": "3.1.0",
-        "unique-string": "2.0.0",
-        "write-file-atomic": "3.0.3",
-        "xdg-basedir": "4.0.0"
+        "dot-prop": "^5.2.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^3.0.0",
+        "unique-string": "^2.0.0",
+        "write-file-atomic": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
       }
     },
     "content-disposition": {
@@ -810,11 +838,22 @@
       "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
       "dev": true,
       "requires": {
-        "@types/parse-json": "4.0.0",
-        "import-fresh": "3.2.1",
-        "parse-json": "5.0.0",
-        "path-type": "4.0.0",
-        "yaml": "1.9.2"
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.7.2"
+      },
+      "dependencies": {
+        "yaml": {
+          "version": "1.9.2",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.9.2.tgz",
+          "integrity": "sha512-HPT7cGGI0DuRcsO51qC1j9O16Dh1mZ2bnXwsi0jrSpsLz0WxOLSLXfkABVl6bZO629py3CU+OMJtpNHDLB97kg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.9.2"
+          }
+        }
       }
     },
     "cross-spawn": {
@@ -823,9 +862,9 @@
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "dev": true,
       "requires": {
-        "path-key": "3.1.1",
-        "shebang-command": "2.0.0",
-        "which": "2.0.2"
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
       }
     },
     "crypto-random-string": {
@@ -860,8 +899,8 @@
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
-        "decamelize": "1.2.0",
-        "map-obj": "1.0.1"
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
       },
       "dependencies": {
         "map-obj": {
@@ -899,13 +938,26 @@
       "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
       "dev": true,
       "requires": {
-        "@types/glob": "7.1.1",
-        "globby": "6.1.0",
-        "is-path-cwd": "2.2.0",
-        "is-path-in-cwd": "2.1.0",
-        "p-map": "2.1.0",
-        "pify": "4.0.1",
-        "rimraf": "2.7.1"
+        "@types/glob": "^7.1.1",
+        "globby": "^6.1.0",
+        "is-path-cwd": "^2.0.0",
+        "is-path-in-cwd": "^2.0.0",
+        "p-map": "^2.0.0",
+        "pify": "^4.0.1",
+        "rimraf": "^2.6.3"
+      },
+      "dependencies": {
+        "@types/glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+          "dev": true,
+          "requires": {
+            "@types/events": "*",
+            "@types/minimatch": "*",
+            "@types/node": "*"
+          }
+        }
       }
     },
     "depd": {
@@ -924,7 +976,7 @@
       "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
       "dev": true,
       "requires": {
-        "is-obj": "2.0.0"
+        "is-obj": "^2.0.0"
       }
     },
     "duplexer3": {
@@ -966,7 +1018,7 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "error-ex": {
@@ -975,7 +1027,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "escape-goat": {
@@ -1022,36 +1074,36 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
       "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
       "requires": {
-        "accepts": "1.3.7",
+        "accepts": "~1.3.7",
         "array-flatten": "1.1.1",
         "body-parser": "1.19.0",
         "content-disposition": "0.5.3",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.4.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
-        "finalhandler": "1.1.2",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.6",
+        "proxy-addr": "~2.0.5",
         "qs": "6.7.0",
-        "range-parser": "1.2.1",
+        "range-parser": "~1.2.1",
         "safe-buffer": "5.1.2",
         "send": "0.17.1",
         "serve-static": "1.14.1",
         "setprototypeof": "1.1.1",
-        "statuses": "1.5.0",
-        "type-is": "1.6.18",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       }
     },
     "external-editor": {
@@ -1060,9 +1112,9 @@
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
       "dev": true,
       "requires": {
-        "chardet": "0.7.0",
-        "iconv-lite": "0.4.24",
-        "tmp": "0.0.33"
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
       }
     },
     "fast-safe-stringify": {
@@ -1081,7 +1133,7 @@
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       },
       "dependencies": {
         "escape-string-regexp": {
@@ -1098,12 +1150,12 @@
       "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.3",
-        "statuses": "1.5.0",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
       }
     },
     "find-up": {
@@ -1112,8 +1164,8 @@
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
       "requires": {
-        "locate-path": "5.0.0",
-        "path-exists": "4.0.0"
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
       }
     },
     "fn.name": {
@@ -1137,9 +1189,9 @@
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.4",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.2"
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
@@ -1154,7 +1206,7 @@
       "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
       "dev": true,
       "requires": {
-        "pump": "3.0.0"
+        "pump": "^3.0.0"
       }
     },
     "github-url-from-git": {
@@ -1169,12 +1221,12 @@
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "global-dirs": {
@@ -1183,7 +1235,7 @@
       "integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
       "dev": true,
       "requires": {
-        "ini": "1.3.5"
+        "ini": "^1.3.5"
       }
     },
     "globby": {
@@ -1192,11 +1244,11 @@
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "glob": "7.1.6",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -1250,11 +1302,29 @@
       "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
       "dev": true,
       "requires": {
-        "minimist": "1.2.5",
-        "neo-async": "2.6.1",
-        "source-map": "0.6.1",
-        "uglify-js": "3.9.2",
-        "wordwrap": "1.0.0"
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "neo-async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+          "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "3.9.2",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.2.tgz",
+          "integrity": "sha512-zGVwKslUAD/EeqOrD1nQaBmXIHl1Vw371we8cvS8I6mYK9rmgX5tv8AAeJdfsQ3Kk5mGax2SVV/AizxdNGhl7Q==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "commander": "~2.20.3"
+          }
+        }
       }
     },
     "hard-rejection": {
@@ -1269,7 +1339,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1292,12 +1362,6 @@
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
       "dev": true
     },
-    "highlight.js": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.1.tgz",
-      "integrity": "sha512-b4L09127uVa+9vkMgPpdUQP78ickGbHEQTWeBrQFTJZ4/n2aihWOGS0ZoUqAwjVmfjhq/C76HRzkqwZhK4sBbg==",
-      "dev": true
-    },
     "hosted-git-info": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.5.tgz",
@@ -1318,10 +1382,10 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
       "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.1",
-        "statuses": "1.5.0",
+        "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
       }
     },
@@ -1336,7 +1400,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "import-fresh": {
@@ -1345,8 +1409,8 @@
       "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
       "dev": true,
       "requires": {
-        "parent-module": "1.0.1",
-        "resolve-from": "4.0.0"
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
       }
     },
     "import-lazy": {
@@ -1373,8 +1437,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1427,9 +1491,9 @@
       "integrity": "sha512-mzNrusCk5L6kSzlN0Ioddn8yzrhYNLli+Sn2ZxMuLechMYAzakiFCIULxsxlQb5YKzthLGfrFACcWoAvM7p04Q==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "inquirer": "6.5.2",
-        "rxjs": "6.5.5"
+        "chalk": "^2.4.1",
+        "inquirer": "^6.2.1",
+        "rxjs": "^6.3.3"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -1450,7 +1514,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -1459,9 +1523,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "cli-cursor": {
@@ -1470,7 +1534,7 @@
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "dev": true,
           "requires": {
-            "restore-cursor": "2.0.0"
+            "restore-cursor": "^2.0.0"
           }
         },
         "cli-width": {
@@ -1506,7 +1570,7 @@
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5"
+            "escape-string-regexp": "^1.0.5"
           }
         },
         "has-flag": {
@@ -1521,25 +1585,31 @@
           "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "3.2.0",
-            "chalk": "2.4.2",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.2.1",
-            "external-editor": "3.1.0",
-            "figures": "2.0.0",
-            "lodash": "4.17.15",
+            "ansi-escapes": "^3.2.0",
+            "chalk": "^2.4.2",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^2.0.0",
+            "lodash": "^4.17.12",
             "mute-stream": "0.0.7",
-            "run-async": "2.4.1",
-            "rxjs": "6.5.5",
-            "string-width": "2.1.1",
-            "strip-ansi": "5.2.0",
-            "through": "2.3.8"
+            "run-async": "^2.2.0",
+            "rxjs": "^6.4.0",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^5.1.0",
+            "through": "^2.3.6"
           }
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         },
         "mimic-fn": {
@@ -1560,7 +1630,7 @@
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
-            "mimic-fn": "1.2.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "restore-cursor": {
@@ -1569,8 +1639,17 @@
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.3"
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "rxjs": {
+          "version": "6.5.5",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
+          "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
           }
         },
         "string-width": {
@@ -1579,8 +1658,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "strip-ansi": {
@@ -1589,7 +1668,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -1600,7 +1679,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -1617,16 +1696,10 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
-    },
-    "interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -1645,7 +1718,7 @@
       "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "dev": true,
       "requires": {
-        "ci-info": "2.0.0"
+        "ci-info": "^2.0.0"
       }
     },
     "is-docker": {
@@ -1666,8 +1739,8 @@
       "integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
       "dev": true,
       "requires": {
-        "global-dirs": "2.0.1",
-        "is-path-inside": "3.0.2"
+        "global-dirs": "^2.0.1",
+        "is-path-inside": "^3.0.1"
       },
       "dependencies": {
         "is-path-inside": {
@@ -1696,7 +1769,7 @@
       "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
       "dev": true,
       "requires": {
-        "symbol-observable": "1.2.0"
+        "symbol-observable": "^1.1.0"
       }
     },
     "is-path-cwd": {
@@ -1711,7 +1784,7 @@
       "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "2.1.0"
+        "is-path-inside": "^2.1.0"
       }
     },
     "is-path-inside": {
@@ -1720,7 +1793,7 @@
       "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.2"
       }
     },
     "is-plain-obj": {
@@ -1741,7 +1814,7 @@
       "integrity": "sha512-Cv4OpPTHAK9kHYzkzCrof3VJh7H/PrG2MBUMvvJebaaUMbqhm0YAtXnvh0I3Hnj2tMZWwrRROWLSgfJrKqWmlQ==",
       "dev": true,
       "requires": {
-        "scoped-regex": "2.1.0"
+        "scoped-regex": "^2.0.0"
       }
     },
     "is-stream": {
@@ -1767,7 +1840,7 @@
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
       "requires": {
-        "is-docker": "2.0.0"
+        "is-docker": "^2.0.0"
       }
     },
     "is-yarn-global": {
@@ -1822,7 +1895,7 @@
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.4"
+        "graceful-fs": "^4.1.6"
       }
     },
     "keyv": {
@@ -1833,12 +1906,6 @@
       "requires": {
         "json-buffer": "3.0.1"
       }
-    },
-    "kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true
     },
     "kuler": {
       "version": "2.0.0",
@@ -1851,7 +1918,7 @@
       "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
       "dev": true,
       "requires": {
-        "package-json": "6.5.0"
+        "package-json": "^6.3.0"
       }
     },
     "lines-and-columns": {
@@ -1891,10 +1958,48 @@
       "integrity": "sha512-oa8iVG870qJq+OuuMK3DjGqFcwsK1SDu+kULp9kEq09TY231aideIZenr3lFOQdASpAr6asuyJBbX62/a3IIhg==",
       "dev": true,
       "requires": {
-        "inquirer": "7.1.0",
-        "inquirer-autosubmit-prompt": "0.2.0",
-        "rxjs": "6.5.5",
-        "through": "2.3.8"
+        "inquirer": "^7.0.0",
+        "inquirer-autosubmit-prompt": "^0.2.0",
+        "rxjs": "^6.5.3",
+        "through": "^2.3.8"
+      },
+      "dependencies": {
+        "cli-width": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+          "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+          "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^3.0.0",
+            "cli-cursor": "^3.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^3.0.0",
+            "lodash": "^4.17.15",
+            "mute-stream": "0.0.8",
+            "run-async": "^2.4.0",
+            "rxjs": "^6.5.3",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "rxjs": {
+          "version": "6.5.5",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
+          "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        }
       }
     },
     "listr-silent-renderer": {
@@ -1909,14 +2014,14 @@
       "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-truncate": "0.2.1",
-        "elegant-spinner": "1.0.1",
-        "figures": "1.7.0",
-        "indent-string": "3.2.0",
-        "log-symbols": "1.0.2",
-        "log-update": "2.3.0",
-        "strip-ansi": "3.0.1"
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "elegant-spinner": "^1.0.1",
+        "figures": "^1.7.0",
+        "indent-string": "^3.0.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^2.3.0",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1937,11 +2042,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "escape-string-regexp": {
@@ -1956,8 +2061,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         },
         "log-symbols": {
@@ -1966,7 +2071,7 @@
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3"
+            "chalk": "^1.0.0"
           }
         },
         "strip-ansi": {
@@ -1975,7 +2080,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -1992,10 +2097,10 @@
       "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "cli-cursor": "2.1.0",
-        "date-fns": "1.30.1",
-        "figures": "2.0.0"
+        "chalk": "^2.4.1",
+        "cli-cursor": "^2.1.0",
+        "date-fns": "^1.27.2",
+        "figures": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2004,7 +2109,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -2013,9 +2118,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "cli-cursor": {
@@ -2024,7 +2129,7 @@
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "dev": true,
           "requires": {
-            "restore-cursor": "2.0.0"
+            "restore-cursor": "^2.0.0"
           }
         },
         "color-convert": {
@@ -2054,7 +2159,7 @@
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5"
+            "escape-string-regexp": "^1.0.5"
           }
         },
         "has-flag": {
@@ -2075,7 +2180,7 @@
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
-            "mimic-fn": "1.2.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "restore-cursor": {
@@ -2084,8 +2189,8 @@
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.3"
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
           }
         },
         "supports-color": {
@@ -2094,7 +2199,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -2105,7 +2210,7 @@
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dev": true,
       "requires": {
-        "p-locate": "4.1.0"
+        "p-locate": "^4.1.0"
       }
     },
     "lodash": {
@@ -2126,7 +2231,7 @@
       "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2"
+        "chalk": "^2.4.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2135,7 +2240,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -2144,9 +2249,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "color-convert": {
@@ -2182,7 +2287,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -2193,9 +2298,9 @@
       "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.2.0",
-        "cli-cursor": "2.1.0",
-        "wrap-ansi": "3.0.1"
+        "ansi-escapes": "^3.0.0",
+        "cli-cursor": "^2.0.0",
+        "wrap-ansi": "^3.0.1"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -2210,7 +2315,7 @@
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "dev": true,
           "requires": {
-            "restore-cursor": "2.0.0"
+            "restore-cursor": "^2.0.0"
           }
         },
         "mimic-fn": {
@@ -2225,7 +2330,7 @@
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
-            "mimic-fn": "1.2.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "restore-cursor": {
@@ -2234,8 +2339,8 @@
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.3"
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
           }
         }
       }
@@ -2286,7 +2391,7 @@
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dev": true,
       "requires": {
-        "semver": "6.3.0"
+        "semver": "^6.0.0"
       },
       "dependencies": {
         "semver": {
@@ -2303,7 +2408,7 @@
       "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
       "dev": true,
       "requires": {
-        "p-defer": "1.0.0"
+        "p-defer": "^1.0.0"
       }
     },
     "map-obj": {
@@ -2329,9 +2434,9 @@
       "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
       "dev": true,
       "requires": {
-        "map-age-cleaner": "0.1.3",
-        "mimic-fn": "2.1.0",
-        "p-is-promise": "2.1.0"
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
       }
     },
     "meow": {
@@ -2340,19 +2445,29 @@
       "integrity": "sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==",
       "dev": true,
       "requires": {
-        "@types/minimist": "1.2.0",
-        "camelcase-keys": "6.2.2",
-        "decamelize-keys": "1.1.0",
-        "hard-rejection": "2.1.0",
-        "minimist-options": "4.0.2",
-        "normalize-package-data": "2.5.0",
-        "read-pkg-up": "7.0.1",
-        "redent": "3.0.0",
-        "trim-newlines": "3.0.0",
-        "type-fest": "0.13.1",
-        "yargs-parser": "18.1.3"
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "^4.0.2",
+        "normalize-package-data": "^2.5.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.13.1",
+        "yargs-parser": "^18.1.3"
       },
       "dependencies": {
+        "minimist-options": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.0.2.tgz",
+          "integrity": "sha512-seq4hpWkYSUh1y7NXxzucwAN9yVlBc3Upgdjz8vLCP97jG8kaOmzYrVH/m7tQ1NYD1wdtZbSLfdy4zFmRWuc/w==",
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "is-plain-obj": "^1.1.0"
+          }
+        },
         "type-fest": {
           "version": "0.13.1",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
@@ -2407,19 +2522,13 @@
       "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
       "dev": true
     },
-    "min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -2427,17 +2536,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
-    },
-    "minimist-options": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-      "dev": true,
-      "requires": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0",
-        "kind-of": "^6.0.3"
-      }
     },
     "ms": {
       "version": "2.0.0",
@@ -2455,19 +2553,13 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
-    "neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true
-    },
     "new-github-release-url": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/new-github-release-url/-/new-github-release-url-1.0.0.tgz",
       "integrity": "sha512-dle7yf655IMjyFUqn6Nxkb18r4AOAkzRcgcZv6WZ0IqrOH4QCEZ8Sm6I7XX21zvHdBeeMeTkhR9qT2Z0EJDx6A==",
       "dev": true,
       "requires": {
-        "type-fest": "0.4.1"
+        "type-fest": "^0.4.1"
       },
       "dependencies": {
         "type-fest": {
@@ -2484,10 +2576,10 @@
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.8.8",
-        "resolve": "1.17.0",
-        "semver": "5.7.1",
-        "validate-npm-package-license": "3.0.4"
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       },
       "dependencies": {
         "hosted-git-info": {
@@ -2587,7 +2679,7 @@
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "dev": true,
       "requires": {
-        "path-key": "3.1.1"
+        "path-key": "^3.0.0"
       }
     },
     "number-is-nan": {
@@ -2621,7 +2713,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "one-time": {
@@ -2638,7 +2730,7 @@
       "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
       "dev": true,
       "requires": {
-        "mimic-fn": "2.1.0"
+        "mimic-fn": "^2.1.0"
       }
     },
     "open": {
@@ -2647,8 +2739,8 @@
       "integrity": "sha512-brSA+/yq+b08Hsr4c8fsEW2CRzk1BmfN3SAK/5VCHQ9bdoZJ4qa/+AfR0xHjlbbZUyPkUHs1b8x1RqdyZdkVqQ==",
       "dev": true,
       "requires": {
-        "is-docker": "2.0.0",
-        "is-wsl": "2.2.0"
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
       }
     },
     "org-regex": {
@@ -2669,7 +2761,7 @@
       "integrity": "sha512-rwiuvCnk3Ug9T4s5oKzw3QXQSiTXlTUiQgHmZ9Ozw/37YzeX8LycosVKOtO3v5+fuARGmCgz9rVhaBJeGV+2bQ==",
       "dev": true,
       "requires": {
-        "type-fest": "0.8.1"
+        "type-fest": "^0.8.1"
       },
       "dependencies": {
         "type-fest": {
@@ -2719,7 +2811,7 @@
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
       "requires": {
-        "p-try": "2.2.0"
+        "p-try": "^2.0.0"
       }
     },
     "p-locate": {
@@ -2728,7 +2820,7 @@
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dev": true,
       "requires": {
-        "p-limit": "2.3.0"
+        "p-limit": "^2.2.0"
       }
     },
     "p-map": {
@@ -2743,8 +2835,8 @@
       "integrity": "sha512-e5tIvrsr7ydUUnxb534iQWtXxWgk/86IsH+H+nV4FHouIggBt4coXboKBt26o4lTu7JbEnGSeXdEsYR8BhAHFA==",
       "dev": true,
       "requires": {
-        "mem": "4.3.0",
-        "mimic-fn": "2.1.0"
+        "mem": "^4.3.0",
+        "mimic-fn": "^2.1.0"
       }
     },
     "p-timeout": {
@@ -2753,7 +2845,7 @@
       "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
       "dev": true,
       "requires": {
-        "p-finally": "1.0.0"
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -2768,10 +2860,10 @@
       "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
       "dev": true,
       "requires": {
-        "got": "9.6.0",
-        "registry-auth-token": "4.1.1",
-        "registry-url": "5.1.0",
-        "semver": "6.3.0"
+        "got": "^9.6.0",
+        "registry-auth-token": "^4.0.0",
+        "registry-url": "^5.0.0",
+        "semver": "^6.2.0"
       },
       "dependencies": {
         "@sindresorhus/is": {
@@ -2897,6 +2989,15 @@
           "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
           "dev": true
         },
+        "registry-auth-token": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
+          "integrity": "sha512-9bKS7nTl9+/A1s7tnPeGrUpRcVY+LUh7bfFgzpndALdPfXQBfQV77rQVtqgUV3ti4vc/Ik81Ex8UJDWDQ12zQA==",
+          "dev": true,
+          "requires": {
+            "rc": "^1.2.8"
+          }
+        },
         "responselike": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
@@ -2926,7 +3027,7 @@
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "requires": {
-        "callsites": "3.1.0"
+        "callsites": "^3.0.0"
       }
     },
     "parse-json": {
@@ -2935,10 +3036,21 @@
       "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.8.3",
-        "error-ex": "1.3.2",
-        "json-parse-better-errors": "1.0.2",
-        "lines-and-columns": "1.1.6"
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1",
+        "lines-and-columns": "^1.1.6"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.8.3"
+          }
+        }
       }
     },
     "parseurl": {
@@ -3005,7 +3117,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -3014,7 +3126,7 @@
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "dev": true,
       "requires": {
-        "find-up": "4.1.0"
+        "find-up": "^4.0.0"
       }
     },
     "prepend-http": {
@@ -3045,7 +3157,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
       "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.1"
       }
     },
@@ -3055,8 +3167,8 @@
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.4",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "pupa": {
@@ -3065,7 +3177,7 @@
       "integrity": "sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==",
       "dev": true,
       "requires": {
-        "escape-goat": "2.1.1"
+        "escape-goat": "^2.0.0"
       },
       "dependencies": {
         "escape-goat": {
@@ -3109,10 +3221,10 @@
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "requires": {
-        "deep-extend": "0.6.0",
-        "ini": "1.3.5",
-        "minimist": "1.2.5",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       }
     },
     "read-pkg": {
@@ -3121,10 +3233,10 @@
       "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
       "dev": true,
       "requires": {
-        "@types/normalize-package-data": "2.4.0",
-        "normalize-package-data": "2.5.0",
-        "parse-json": "5.0.0",
-        "type-fest": "0.6.0"
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
       },
       "dependencies": {
         "type-fest": {
@@ -3141,9 +3253,9 @@
       "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
       "dev": true,
       "requires": {
-        "find-up": "4.1.0",
-        "read-pkg": "5.2.0",
-        "type-fest": "0.8.1"
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
       },
       "dependencies": {
         "type-fest": {
@@ -3159,9 +3271,9 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "requires": {
-        "inherits": "2.0.3",
-        "string_decoder": "1.3.0",
-        "util-deprecate": "1.0.2"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "rechoir": {
@@ -3170,7 +3282,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.17.0"
+        "resolve": "^1.1.6"
       }
     },
     "redent": {
@@ -3179,8 +3291,8 @@
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
       "dev": true,
       "requires": {
-        "indent-string": "4.0.0",
-        "strip-indent": "3.0.0"
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
       },
       "dependencies": {
         "indent-string": {
@@ -3191,13 +3303,19 @@
         }
       }
     },
+    "regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+      "dev": true
+    },
     "registry-auth-token": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.0.tgz",
       "integrity": "sha512-P+lWzPrsgfN+UEpDS3U8AQKg/UjZX6mQSJueZj3EK+vNESoqBSpBUD3gmu4sF9lOsjXWjF11dQKUqemf3veq1w==",
       "dev": true,
       "requires": {
-        "rc": "1.2.8"
+        "rc": "^1.2.8"
       }
     },
     "registry-url": {
@@ -3206,7 +3324,7 @@
       "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
       "dev": true,
       "requires": {
-        "rc": "1.2.8"
+        "rc": "^1.2.8"
       }
     },
     "resolve": {
@@ -3215,7 +3333,7 @@
       "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.6"
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-from": {
@@ -3239,8 +3357,8 @@
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "requires": {
-        "onetime": "5.1.0",
-        "signal-exit": "3.0.3"
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "rimraf": {
@@ -3249,7 +3367,7 @@
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.6"
+        "glob": "^7.1.3"
       }
     },
     "run-async": {
@@ -3264,7 +3382,15 @@
       "integrity": "sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==",
       "dev": true,
       "requires": {
-        "tslib": "1.11.1"
+        "tslib": "^1.9.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+          "dev": true
+        }
       }
     },
     "safe-buffer": {
@@ -3295,7 +3421,7 @@
       "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
       "dev": true,
       "requires": {
-        "semver": "6.3.0"
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "semver": {
@@ -3312,18 +3438,18 @@
       "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.7.2",
+        "http-errors": "~1.7.2",
         "mime": "1.6.0",
         "ms": "2.1.1",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.1",
-        "statuses": "1.5.0"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
       },
       "dependencies": {
         "ms": {
@@ -3338,9 +3464,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
       "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.3",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
         "send": "0.17.1"
       }
     },
@@ -3355,7 +3481,7 @@
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "requires": {
-        "shebang-regex": "3.0.0"
+        "shebang-regex": "^3.0.0"
       }
     },
     "shebang-regex": {
@@ -3370,9 +3496,17 @@
       "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
       "dev": true,
       "requires": {
-        "glob": "7.1.6",
-        "interpret": "1.2.0",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "dependencies": {
+        "interpret": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+          "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+          "dev": true
+        }
       }
     },
     "signal-exit": {
@@ -3386,7 +3520,7 @@
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "requires": {
-        "is-arrayish": "0.3.2"
+        "is-arrayish": "^0.3.1"
       },
       "dependencies": {
         "is-arrayish": {
@@ -3408,31 +3542,11 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
     },
-    "spdx-correct": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
-      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
-      "dev": true,
-      "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.5"
-      }
-    },
     "spdx-exceptions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
       "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
       "dev": true
-    },
-    "spdx-expression-parse": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "dev": true,
-      "requires": {
-        "spdx-exceptions": "2.3.0",
-        "spdx-license-ids": "3.0.5"
-      }
     },
     "spdx-license-ids": {
       "version": "3.0.5",
@@ -3446,7 +3560,7 @@
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "stack-trace": {
@@ -3465,9 +3579,9 @@
       "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
       "dev": true,
       "requires": {
-        "emoji-regex": "8.0.0",
-        "is-fullwidth-code-point": "3.0.0",
-        "strip-ansi": "6.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
       }
     },
     "string_decoder": {
@@ -3475,13 +3589,13 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
-        "safe-buffer": "5.2.0"
+        "safe-buffer": "~5.2.0"
       },
       "dependencies": {
         "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
         }
       }
     },
@@ -3491,7 +3605,7 @@
       "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
       "dev": true,
       "requires": {
-        "ansi-regex": "5.0.0"
+        "ansi-regex": "^5.0.0"
       }
     },
     "strip-final-newline": {
@@ -3506,7 +3620,15 @@
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
       "dev": true,
       "requires": {
-        "min-indent": "1.0.0"
+        "min-indent": "^1.0.0"
+      },
+      "dependencies": {
+        "min-indent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
+          "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
+          "dev": true
+        }
       }
     },
     "strip-json-comments": {
@@ -3521,7 +3643,7 @@
       "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
       "dev": true,
       "requires": {
-        "has-flag": "4.0.0"
+        "has-flag": "^4.0.0"
       }
     },
     "supports-hyperlinks": {
@@ -3530,8 +3652,8 @@
       "integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
       "dev": true,
       "requires": {
-        "has-flag": "4.0.0",
-        "supports-color": "7.1.0"
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
       }
     },
     "symbol-observable": {
@@ -3552,8 +3674,8 @@
       "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "4.3.1",
-        "supports-hyperlinks": "2.1.0"
+        "ansi-escapes": "^4.2.1",
+        "supports-hyperlinks": "^2.0.0"
       }
     },
     "text-hex": {
@@ -3573,7 +3695,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-readable-stream": {
@@ -3616,7 +3738,7 @@
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.27"
+        "mime-types": "~2.1.24"
       }
     },
     "typedarray-to-buffer": {
@@ -3625,7 +3747,7 @@
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dev": true,
       "requires": {
-        "is-typedarray": "1.0.0"
+        "is-typedarray": "^1.0.0"
       }
     },
     "typedoc": {
@@ -3634,16 +3756,30 @@
       "integrity": "sha512-/OyrHCJ8jtzu+QZ+771YaxQ9s4g5Z3XsQE3Ma7q+BL392xxBn4UMvvCdVnqKC2T/dz03/VXSLVKOP3lHmDdc/w==",
       "dev": true,
       "requires": {
-        "fs-extra": "8.1.0",
-        "handlebars": "4.7.6",
-        "highlight.js": "10.0.2",
-        "lodash": "4.17.15",
-        "lunr": "2.3.8",
+        "fs-extra": "^8.1.0",
+        "handlebars": "^4.7.6",
+        "highlight.js": "^10.0.0",
+        "lodash": "^4.17.15",
+        "lunr": "^2.3.8",
         "marked": "1.0.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
         "shelljs": "^0.8.4",
         "typedoc-default-themes": "^0.10.2"
+      },
+      "dependencies": {
+        "highlight.js": {
+          "version": "10.0.2",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.0.2.tgz",
+          "integrity": "sha512-2gMT2MHU6/2OjAlnaOE2LFdr9dwviDN3Q2lSw7Ois3/5uTtahbgYTkr4EPoY828ps+2eQWiixPTF8+phU6Ofkg==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "typedoc-default-themes": {
@@ -3652,7 +3788,7 @@
       "integrity": "sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==",
       "dev": true,
       "requires": {
-        "lunr": "2.3.8"
+        "lunr": "^2.3.8"
       }
     },
     "typescript": {
@@ -3661,20 +3797,13 @@
       "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
       "dev": true
     },
-    "uglify-js": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
-      "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==",
-      "dev": true,
-      "optional": true
-    },
     "unique-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
       "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
       "dev": true,
       "requires": {
-        "crypto-random-string": "2.0.0"
+        "crypto-random-string": "^2.0.0"
       }
     },
     "universalify": {
@@ -3694,19 +3823,19 @@
       "integrity": "sha512-w3doE1qtI0/ZmgeoDoARmI5fjDoT93IfKgEGqm26dGUOh8oNpaSTsGNdYRN/SjOuo10jcJGwkEL3mroKzktkew==",
       "dev": true,
       "requires": {
-        "boxen": "4.2.0",
-        "chalk": "3.0.0",
-        "configstore": "5.0.1",
-        "has-yarn": "2.1.0",
-        "import-lazy": "2.1.0",
-        "is-ci": "2.0.0",
-        "is-installed-globally": "0.3.2",
-        "is-npm": "4.0.0",
-        "is-yarn-global": "0.3.0",
-        "latest-version": "5.1.0",
-        "pupa": "2.0.1",
-        "semver-diff": "3.1.1",
-        "xdg-basedir": "4.0.0"
+        "boxen": "^4.2.0",
+        "chalk": "^3.0.0",
+        "configstore": "^5.0.1",
+        "has-yarn": "^2.1.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^2.0.0",
+        "is-installed-globally": "^0.3.1",
+        "is-npm": "^4.0.0",
+        "is-yarn-global": "^0.3.0",
+        "latest-version": "^5.0.0",
+        "pupa": "^2.0.1",
+        "semver-diff": "^3.1.1",
+        "xdg-basedir": "^4.0.0"
       }
     },
     "url-parse-lax": {
@@ -3715,7 +3844,7 @@
       "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
       "dev": true,
       "requires": {
-        "prepend-http": "2.0.0"
+        "prepend-http": "^2.0.0"
       }
     },
     "util-deprecate": {
@@ -3734,8 +3863,30 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.1.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      },
+      "dependencies": {
+        "spdx-correct": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+          "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+          "dev": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        }
       }
     },
     "validate-npm-package-name": {
@@ -3744,7 +3895,7 @@
       "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "dev": true,
       "requires": {
-        "builtins": "1.0.3"
+        "builtins": "^1.0.3"
       }
     },
     "vary": {
@@ -3758,7 +3909,7 @@
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "widest-line": {
@@ -3767,7 +3918,7 @@
       "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
       "dev": true,
       "requires": {
-        "string-width": "4.2.0"
+        "string-width": "^4.0.0"
       }
     },
     "winston": {
@@ -3800,13 +3951,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.1",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -3814,7 +3965,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -3831,8 +3982,8 @@
       "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0"
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3853,8 +4004,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -3863,7 +4014,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -3880,10 +4031,10 @@
       "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
       "dev": true,
       "requires": {
-        "imurmurhash": "0.1.4",
-        "is-typedarray": "1.0.0",
-        "signal-exit": "3.0.3",
-        "typedarray-to-buffer": "3.1.5"
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
       }
     },
     "xdg-basedir": {
@@ -3898,20 +4049,14 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
-    "yaml": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
-      "dev": true
-    },
     "yargs-parser": {
       "version": "18.1.3",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
       "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "dev": true,
       "requires": {
-        "camelcase": "5.3.1",
-        "decamelize": "1.2.0"
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
       }
     }
   }

--- a/packages/program-boilerplate/package-lock.json
+++ b/packages/program-boilerplate/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.5-5",
+  "version": "3.5.5-6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/program-boilerplate/package.json
+++ b/packages/program-boilerplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.5-4",
+  "version": "3.5.5-5",
   "description": "Boilerplate for writing programs",
   "main": "dist/index.js",
   "files": [

--- a/packages/program-boilerplate/package.json
+++ b/packages/program-boilerplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.5-0",
+  "version": "3.5.4",
   "description": "Boilerplate for writing programs",
   "main": "dist/index.js",
   "files": [

--- a/packages/program-boilerplate/package.json
+++ b/packages/program-boilerplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.5-1",
+  "version": "3.5.5-2",
   "description": "Boilerplate for writing programs",
   "main": "dist/index.js",
   "files": [

--- a/packages/program-boilerplate/package.json
+++ b/packages/program-boilerplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.5-8",
+  "version": "3.5.5-9",
   "description": "Boilerplate for writing programs",
   "main": "dist/index.js",
   "files": [

--- a/packages/program-boilerplate/package.json
+++ b/packages/program-boilerplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.5-3",
+  "version": "3.5.5-4",
   "description": "Boilerplate for writing programs",
   "main": "dist/index.js",
   "files": [

--- a/packages/program-boilerplate/package.json
+++ b/packages/program-boilerplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.5-9",
+  "version": "3.5.5",
   "description": "Boilerplate for writing programs",
   "main": "dist/index.js",
   "files": [

--- a/packages/program-boilerplate/package.json
+++ b/packages/program-boilerplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.5-0",
+  "version": "3.5.5-1",
   "description": "Boilerplate for writing programs",
   "main": "dist/index.js",
   "files": [

--- a/packages/program-boilerplate/package.json
+++ b/packages/program-boilerplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.4",
+  "version": "3.5.5-0",
   "description": "Boilerplate for writing programs",
   "main": "dist/index.js",
   "files": [

--- a/packages/program-boilerplate/package.json
+++ b/packages/program-boilerplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.5-5",
+  "version": "3.5.5-6",
   "description": "Boilerplate for writing programs",
   "main": "dist/index.js",
   "files": [

--- a/packages/program-boilerplate/package.json
+++ b/packages/program-boilerplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.5-2",
+  "version": "3.5.5-3",
   "description": "Boilerplate for writing programs",
   "main": "dist/index.js",
   "files": [

--- a/packages/program-boilerplate/package.json
+++ b/packages/program-boilerplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.5-7",
+  "version": "3.5.5-8",
   "description": "Boilerplate for writing programs",
   "main": "dist/index.js",
   "files": [

--- a/packages/program-boilerplate/package.json
+++ b/packages/program-boilerplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.5-6",
+  "version": "3.5.5-7",
   "description": "Boilerplate for writing programs",
   "main": "dist/index.js",
   "files": [

--- a/packages/program-boilerplate/src/index.ts
+++ b/packages/program-boilerplate/src/index.ts
@@ -1,11 +1,11 @@
-import * as express from 'express';
+import * as express from "express";
 
-import {meetCustomFieldRules, meetEventTriggerRules} from './conversion';
-import {rewardEmailQuery} from './queries';
-import Transaction from './transaction';
-import {triggerProgram} from './trigger';
-import {getLogger} from './logger';
-import * as types from './types';
+import { meetCustomFieldRules, meetEventTriggerRules } from "./conversion";
+import { rewardEmailQuery } from "./queries";
+import Transaction from "./transaction";
+import { triggerProgram } from "./trigger";
+import { getLogger, setLogLevel } from "./logger";
+import * as types from "./types";
 
 import {
   Program,
@@ -13,20 +13,20 @@ import {
   RequirementValidationResult,
   ValidationProgramField,
   ProgramTriggerBody,
-} from './types/rpc';
+} from "./types/rpc";
 
-import {timeboxExpression, safeJsonata} from './jsonata';
+import { timeboxExpression, safeJsonata } from "./jsonata";
 
-import {ProgramType} from './types/saasquatch';
+import { ProgramType } from "./types/saasquatch";
 import {
   inferType,
   getGoalAnalyticTimestamp,
   setRewardSchedule,
   numToEquality,
   getTriggerSchema,
-} from './utils';
+} from "./utils";
 
-export {types};
+export { types };
 
 export {
   Transaction,
@@ -48,6 +48,7 @@ export {
   timeboxExpression,
   safeJsonata,
   getLogger,
+  setLogLevel,
 };
 
 /**
@@ -59,8 +60,8 @@ export {
  * @return {Object} The express server
  */
 export function webtask(program: Program = {}): express.Application {
-  const bodyParser = require('body-parser');
-  const compression = require('compression');
+  const bodyParser = require("body-parser");
+  const compression = require("compression");
 
   const app = express();
 
@@ -71,18 +72,18 @@ export function webtask(program: Program = {}): express.Application {
   // because OWASP advises not to
   app.use((req, res, next) => {
     if (
-      process.env.NODE_ENV === 'production' &&
-      req.header('X-Forwarded-Proto') !== 'https'
+      process.env.NODE_ENV === "production" &&
+      req.header("X-Forwarded-Proto") !== "https"
     ) {
-      return res.status(403).send({message: 'SSL required'});
+      return res.status(403).send({ message: "SSL required" });
     }
 
     // allow the request to continue if https is used
     next();
   });
 
-  app.post('/*', (context, res) => {
-    const {json, code} = triggerProgram(context.body, program);
+  app.post("/*", (context, res) => {
+    const { json, code } = triggerProgram(context.body, program);
 
     res.status(code).json(json);
   });

--- a/packages/program-boilerplate/src/jsonata.ts
+++ b/packages/program-boilerplate/src/jsonata.ts
@@ -63,7 +63,7 @@ export function safeJsonata(expression: string, inputData: any) {
     const jsonataQuery = jsonata(expression);
     timeboxExpression(jsonataQuery);
     return jsonataQuery.evaluate(inputData);
-  } catch {
-    logger.warn('Failed to evaluate JSONata expression');
+  } catch(e) {
+    logger.warn(`Failed to evaluate JSONata expression: ${e.message}`);
   }
 }

--- a/packages/program-boilerplate/src/logger.ts
+++ b/packages/program-boilerplate/src/logger.ts
@@ -1,4 +1,4 @@
-import {createLogger, format, Logger, transports} from 'winston';
+import { createLogger, format, Logger, transports } from "winston";
 
 // Lazily initialized logger instance
 let _logger: Logger;
@@ -16,7 +16,7 @@ export function getLogger(logLevel: string): Logger {
     return _logger;
   }
 
-  const logFormat = format.printf(({level, message}) => {
+  const logFormat = format.printf(({ level, message }) => {
     return `[${level.toUpperCase()}] ${message}`;
   });
 
@@ -27,4 +27,15 @@ export function getLogger(logLevel: string): Logger {
   });
 
   return _logger;
+}
+
+/**
+ * Set the log level of the singleton logger.
+ *
+ * @param {string} logLevel The log level
+ */
+export function setLogLevel(logLevel: string) {
+  if (!_logger) return;
+
+  _logger.level = logLevel;
 }

--- a/packages/program-boilerplate/src/transaction.ts
+++ b/packages/program-boilerplate/src/transaction.ts
@@ -1,369 +1,364 @@
 // @ts-check
 import {
-  rewardEmailQuery,
-  nonRewardEmailQueryForReferralPrograms,
-  rewardEmailQueryForNonReferralPrograms,
-} from './queries';
+ rewardEmailQuery,
+ nonRewardEmailQueryForReferralPrograms,
+ rewardEmailQueryForNonReferralPrograms,
+} from "./queries";
 
-import {ProgramTriggerBody} from './types/rpc';
-import {ProgramType, User} from './types/saasquatch';
-import ObjectID from 'bson-objectid';
+import { ProgramTriggerBody } from "./types/rpc";
+import { ProgramType, User } from "./types/saasquatch";
+import ObjectID from "bson-objectid";
 
 type TransactionContext = {
-  body: ProgramTriggerBody;
+ body: ProgramTriggerBody;
 };
 
 type ReferralRewardInput = {
-  rewardKey: string;
-  user: User;
-  referralId: string;
-  userEvent?: any;
-  rewardSource?: string;
-  status?: string;
-  rewardProperties?: any;
-  overrideProperties?: {
-    dateScheduledFor?: number | null;
-    dateExpires?: number | null;
-  };
-  dynamicProperties?: {
-    dateScheduledFor?: number | null;
-    dateExpires?: number | null;
-    type: string;
-    unit: string;
-    assignedCredit: number;
-  };
+ rewardKey: string;
+ user: User;
+ referralId: string;
+ userEvent?: any;
+ rewardSource?: string;
+ status?: string;
+ overrideProperties?: {
+  dateScheduledFor?: number | null;
+  dateExpires?: number | null;
+ };
+ dynamicProperties?: {
+  dateScheduledFor?: number | null;
+  dateExpires?: number | null;
+  type: string;
+  unit: string;
+  assignedCredit: number;
+ };
 };
 
 export default class Transaction {
-  mutations: any[];
-  analytics: any[];
-  context: TransactionContext;
-  currentUser: User;
-  events?: any[];
+ mutations: any[];
+ analytics: any[];
+ context: TransactionContext;
+ currentUser: User;
+ events?: any[];
 
-  /**
-   * @classdesc A Transaction instance takes a context object from Express, generates mutations and analytics as the program requested.
-   * @constructor
-   *
-   * @param {TransactionContext} context   A javascript object passed by webtask.
-   * @param {Object[]}           mutations Mutations to be made on the program.
-   * @param {Object[]}           analytics Analytics of the program.
-   */
-  constructor(
-    context: TransactionContext,
-    mutations: any = [],
-    analytics: any = [],
-  ) {
-    this.mutations = mutations;
-    this.analytics = analytics;
-    this.context = context;
+ /**
+  * @classdesc A Transaction instance takes a context object from Express, generates mutations and analytics as the program requested.
+  * @constructor
+  *
+  * @param {TransactionContext} context   A javascript object passed by webtask.
+  * @param {Object[]}           mutations Mutations to be made on the program.
+  * @param {Object[]}           analytics Analytics of the program.
+  */
+ constructor(
+  context: TransactionContext,
+  mutations: any = [],
+  analytics: any = []
+ ) {
+  this.mutations = mutations;
+  this.analytics = analytics;
+  this.context = context;
 
-    const activeTrigger = context.body.activeTrigger;
+  const activeTrigger = context.body.activeTrigger;
 
-    this.currentUser = activeTrigger.user;
-    this.events = activeTrigger.events;
+  this.currentUser = activeTrigger.user;
+  this.events = activeTrigger.events;
+ }
+
+ /**
+  * Generates a PROGRAM_EVALUATED analytic and pushes it
+  * to the list of analytics.
+  *
+  * @param {User}        user The user to associate the analytic with
+  * @param {ProgramType} type The type of program
+  */
+ fireProgramEvalAnalytics(user: User, type: ProgramType) {
+  const evalAnalytic = {
+   eventType: "PROGRAM_EVALUATED",
+   data: {
+    user: {
+     id: user.id,
+     accountId: user.accountId,
+    },
+    programType: type,
+   },
+  };
+
+  this.analytics.push(evalAnalytic);
+ }
+
+ /**
+  * Generates a PROGRAM_GOAL analytic and pushs it
+  * to the list of analytics.
+  *
+  * @param {object} user              user who achieved the program goal
+  * @param {string} programType       type of program
+  * @param {string} analyticsKey      type of goal achieved
+  * @param {string} analyticsDedupeId dedupe id of the analytic event
+  * @param {number} timestamp         timestamp of the event
+  * @param {boolean} isConversion     whether the analytic should convert the referral
+  */
+ fireProgramGoalAnalytics(
+  user: User,
+  programType: ProgramType,
+  analyticsKey: string,
+  analyticsDedupeId: string | null,
+  timestamp: number,
+  isConversion: boolean = true
+ ) {
+  const goalAnalytic = {
+   eventType: "PROGRAM_GOAL",
+   data: {
+    programType,
+    timestamp,
+    analyticsKey,
+    analyticsDedupeId,
+    user: {
+     id: user.id,
+     accountId: user.accountId,
+    },
+    isConversion,
+   },
+  };
+
+  this.analytics.push(goalAnalytic);
+ }
+
+ /**
+  * Generates a reward that does not relates to any referral, for the currrent user.
+  *
+  * @param {string} rewardKey - Key of the reward (as defined in contentful).
+  */
+ generateSimpleReward(rewardKey: string) {
+  const rewardId = ObjectID.generate();
+  const newMutation = {
+   type: "CREATE_REWARD",
+   data: {
+    user: {
+     id: this.currentUser.id,
+     accountId: this.currentUser.accountId,
+    },
+    key: rewardKey,
+    rewardId: rewardId,
+   },
+  };
+
+  this.mutations = [...this.mutations, newMutation];
+  return { rewardId };
+ }
+
+ /**
+  * Generates reward for a user of a referral.
+  *
+  * @param {string} rewardKey  Key of the reward (as defined in Contentful).
+  * @param {User}   user       The user to be given reward to (can be either referrer or referred user).
+  * @param {string} referralId id of the referral.
+  */
+ generateReferralReward(input: ReferralRewardInput) {
+  const {
+   rewardKey,
+   user,
+   referralId,
+   userEvent,
+   rewardSource,
+   status,
+   overrideProperties,
+   dynamicProperties,
+  } = input;
+
+  const rewardId = ObjectID.generate();
+  const rewardData = {
+   user: {
+    id: user.id,
+    accountId: user.accountId,
+   },
+   key: rewardKey,
+   rewardId: rewardId,
+   referralId: referralId,
+   overrideProperties,
+   dynamicProperties,
+  };
+
+  const validProperties = [{ userEvent }, { rewardSource }, { status }].filter(
+   (prop) => prop !== undefined
+  );
+  const updatedRewardData = validProperties.reduce((currentData, prop) => {
+   return { ...currentData, ...prop };
+  }, rewardData);
+
+  const newMutation = {
+   type: "CREATE_REWARD",
+   data: updatedRewardData,
+  };
+
+  this.mutations = [...this.mutations, newMutation];
+  return { rewardId };
+ }
+
+ /**
+  * Generates an email for the user.
+  *
+  * @param {string} emailKey Key of email template (as defined in Contentful).
+  * @param {User}   user     The user to be sent a email to
+  * @param {string} rewardId The reward id
+  */
+ generateSimpleEmail({
+  emailKey,
+  user,
+  rewardId,
+ }: {
+  emailKey: string;
+  user: User;
+  rewardId: any;
+ }) {
+  if (!rewardId) {
+   throw new Error("rewardId must be provided before email sent.");
   }
 
-  /**
-   * Generates a PROGRAM_EVALUATED analytic and pushes it
-   * to the list of analytics.
-   *
-   * @param {User}        user The user to associate the analytic with
-   * @param {ProgramType} type The type of program
-   */
-  fireProgramEvalAnalytics(user: User, type: ProgramType) {
-    const evalAnalytic = {
-      eventType: 'PROGRAM_EVALUATED',
-      data: {
-        user: {
-          id: user.id,
-          accountId: user.accountId,
-        },
-        programType: type,
-      },
-    };
+  const queryVariables = {
+   userId: user.id,
+   accountId: user.accountId,
+   rewardId: rewardId,
+   programId: this.context.body.program.id,
+  };
 
-    this.analytics.push(evalAnalytic);
-  }
+  const newMutation = {
+   type: "SEND_EMAIL",
+   data: {
+    user: {
+     id: user.id,
+     accountId: user.accountId,
+    },
+    key: emailKey,
+    queryVariables: queryVariables,
+    query: rewardEmailQueryForNonReferralPrograms,
+    rewardId: rewardId,
+   },
+  };
 
-  /**
-   * Generates a PROGRAM_GOAL analytic and pushs it
-   * to the list of analytics.
-   *
-   * @param {object} user              user who achieved the program goal
-   * @param {string} programType       type of program
-   * @param {string} analyticsKey      type of goal achieved
-   * @param {string} analyticsDedupeId dedupe id of the analytic event
-   * @param {number} timestamp         timestamp of the event
-   * @param {boolean} isConversion     whether the analytic should convert the referral
-   */
-  fireProgramGoalAnalytics(
-    user: User,
-    programType: ProgramType,
-    analyticsKey: string,
-    analyticsDedupeId: string | null,
-    timestamp: number,
-    isConversion: boolean = true
-  ) {
-    const goalAnalytic = {
-      eventType: 'PROGRAM_GOAL',
-      data: {
-        programType,
-        timestamp,
-        analyticsKey,
-        analyticsDedupeId,
-        user: {
-          id: user.id,
-          accountId: user.accountId,
-        },
-        isConversion
-      },
-    };
+  this.mutations = [...this.mutations, newMutation];
+ }
 
-    this.analytics.push(goalAnalytic);
-  }
+ generateReferralEmail({
+  emailKey,
+  user,
+  referralId,
+  rewardId,
+ }: {
+  emailKey: string;
+  user: User;
+  referralId: string;
+  rewardId?: string;
+ }) {
+  const variables = {
+   userId: user.id,
+   accountId: user.accountId,
+   programId: this.context.body.program.id,
+   referralId: referralId,
+  };
 
-  /**
-   * Generates a reward that does not relates to any referral, for the currrent user.
-   *
-   * @param {string} rewardKey - Key of the reward (as defined in contentful).
-   */
-  generateSimpleReward(rewardKey: string) {
-    const rewardId = ObjectID.generate();
-    const newMutation = {
-      type: 'CREATE_REWARD',
-      data: {
-        user: {
-          id: this.currentUser.id,
-          accountId: this.currentUser.accountId,
-        },
-        key: rewardKey,
-        rewardId: rewardId,
-      },
-    };
-
-    this.mutations = [...this.mutations, newMutation];
-    return {rewardId};
-  }
-
-  /**
-   * Generates reward for a user of a referral.
-   *
-   * @param {string} rewardKey  Key of the reward (as defined in Contentful).
-   * @param {User}   user       The user to be given reward to (can be either referrer or referred user).
-   * @param {string} referralId id of the referral.
-   */
-  generateReferralReward(input: ReferralRewardInput) {
-    const {
-      rewardKey,
-      user,
-      referralId,
-      userEvent,
-      rewardSource,
-      status,
-      overrideProperties,
-      dynamicProperties,
-    } = input;
-
-    const rewardId = ObjectID.generate();
-    const rewardData = {
-      user: {
-        id: user.id,
-        accountId: user.accountId,
-      },
-      key: rewardKey,
-      rewardId: rewardId,
-      referralId: referralId,
-      overrideProperties,
-      dynamicProperties
-    };
-
-    const validProperties = [
-      {userEvent},
-      {rewardSource},
-      {status},
-    ].filter((prop) => prop !== undefined);
-    const updatedRewardData = validProperties.reduce((currentData, prop) => {
-      return {...currentData, ...prop};
-    }, rewardData);
-
-    const newMutation = {
-      type: 'CREATE_REWARD',
-      data: updatedRewardData,
-    };
-
-    this.mutations = [...this.mutations, newMutation];
-    return {rewardId};
-  }
-
-  /**
-   * Generates an email for the user.
-   *
-   * @param {string} emailKey Key of email template (as defined in Contentful).
-   * @param {User}   user     The user to be sent a email to
-   * @param {string} rewardId The reward id
-   */
-  generateSimpleEmail({
-    emailKey,
-    user,
+  const queryVariables = rewardId ? { ...variables, rewardId } : variables;
+  const newMutation = {
+   type: "SEND_EMAIL",
+   data: {
+    user: {
+     id: user.id,
+     accountId: user.accountId,
+    },
     rewardId,
-  }: {
-    emailKey: string;
-    user: User;
-    rewardId: any;
-  }) {
-    if (!rewardId) {
-      throw new Error('rewardId must be provided before email sent.');
-    }
+    key: emailKey,
+    queryVariables: queryVariables,
+    query: rewardId ? rewardEmailQuery : nonRewardEmailQueryForReferralPrograms,
+   },
+  };
+  this.mutations = [...this.mutations, newMutation];
+ }
 
-    const queryVariables = {
-      userId: user.id,
-      accountId: user.accountId,
-      rewardId: rewardId,
-      programId: this.context.body.program.id,
-    };
+ /**
+  * Generates both reward and email.
+  */
+ generateSimpleRewardAndEmail({
+  emailKey,
+  rewardKey,
+  user,
+ }: {
+  emailKey: string;
+  rewardKey: string;
+  user: User;
+ }) {
+  const { rewardId } = this.generateSimpleReward(rewardKey);
+  this.generateSimpleEmail({ emailKey, user, rewardId });
+ }
 
-    const newMutation = {
-      type: 'SEND_EMAIL',
-      data: {
-        user: {
-          id: user.id,
-          accountId: user.accountId,
-        },
-        key: emailKey,
-        queryVariables: queryVariables,
-        query: rewardEmailQueryForNonReferralPrograms,
-        rewardId: rewardId,
+ /**
+  * Generates both reward and email for a referral.
+  */
+ generateReferralRewardAndEmail({
+  emailKey,
+  rewardKey,
+  referralId,
+  user,
+  status,
+  overrideProperties,
+  dynamicProperties,
+ }: {
+  emailKey: string;
+  rewardKey: string;
+  referralId: string;
+  user: User;
+  status?: string;
+  overrideProperties?: any;
+  dynamicProperties?: any;
+ }) {
+  const { rewardId } = this.generateReferralReward({
+   rewardKey,
+   referralId,
+   user,
+   userEvent: undefined,
+   rewardSource: undefined,
+   status,
+   overrideProperties,
+   dynamicProperties,
+  });
+
+  this.generateReferralEmail({ emailKey, user, referralId, rewardId });
+ }
+
+ generateRefunds() {
+  const refundEvents = (this.events || []).filter(
+   (e) =>
+    e.key === "refund" &&
+    e.fields &&
+    // we can't do much if there's no order_id
+    e.fields.order_id
+  );
+  refundEvents.forEach((refundEvent) => {
+   const refundNode = {
+    type: "MODERATE_GRAPH_NODES",
+    data: {
+     graphNodeType: "USER_EVENT",
+     filter: {
+      key: "purchase",
+      fields: {
+       order_id_eq: refundEvent.fields.order_id,
       },
-    };
+     },
+     moderationInput: {
+      action: "DENY",
+      maxDepth: 5,
+     },
+    },
+   };
+   this.mutations = [...this.mutations, refundNode];
+  });
+ }
 
-    this.mutations = [...this.mutations, newMutation];
-  }
-
-  generateReferralEmail({
-    emailKey,
-    user,
-    referralId,
-    rewardId,
-  }: {
-    emailKey: string;
-    user: User;
-    referralId: string;
-    rewardId?: string;
-  }) {
-    const variables = {
-      userId: user.id,
-      accountId: user.accountId,
-      programId: this.context.body.program.id,
-      referralId: referralId,
-    };
-
-    const queryVariables = rewardId ? {...variables, rewardId} : variables;
-    const newMutation = {
-      type: 'SEND_EMAIL',
-      data: {
-        user: {
-          id: user.id,
-          accountId: user.accountId,
-        },
-        rewardId,
-        key: emailKey,
-        queryVariables: queryVariables,
-        query: rewardId
-          ? rewardEmailQuery
-          : nonRewardEmailQueryForReferralPrograms,
-      },
-    };
-    this.mutations = [...this.mutations, newMutation];
-  }
-
-  /**
-   * Generates both reward and email.
-   */
-  generateSimpleRewardAndEmail({
-    emailKey,
-    rewardKey,
-    user,
-  }: {
-    emailKey: string;
-    rewardKey: string;
-    user: User;
-  }) {
-    const {rewardId} = this.generateSimpleReward(rewardKey);
-    this.generateSimpleEmail({emailKey, user, rewardId});
-  }
-
-  /**
-   * Generates both reward and email for a referral.
-   */
-  generateReferralRewardAndEmail({
-    emailKey,
-    rewardKey,
-    referralId,
-    user,
-    status,
-    overrideProperties,
-    dynamicProperties
-  }: {
-    emailKey: string;
-    rewardKey: string;
-    referralId: string;
-    user: User;
-    status?: string;
-    overrideProperties?: any;
-    dynamicProperties?: any;
-  }) {
-    const {rewardId} = this.generateReferralReward({
-      rewardKey,
-      referralId,
-      user,
-      userEvent: undefined,
-      rewardSource: undefined,
-      status,
-      overrideProperties,
-      dynamicProperties
-    });
-
-    this.generateReferralEmail({emailKey, user, referralId, rewardId});
-  }
-
-  generateRefunds() {
-    const refundEvents = (this.events || []).filter(
-      (e) =>
-        e.key === 'refund' &&
-        e.fields &&
-        // we can't do much if there's no order_id
-        e.fields.order_id,
-    );
-    refundEvents.forEach((refundEvent) => {
-      const refundNode = {
-        type: 'MODERATE_GRAPH_NODES',
-        data: {
-          graphNodeType: 'USER_EVENT',
-          filter: {
-            key: 'purchase',
-            fields: {
-              order_id_eq: refundEvent.fields.order_id,
-            },
-          },
-          moderationInput: {
-            action: 'DENY',
-            maxDepth: 5,
-          },
-        },
-      };
-      this.mutations = [...this.mutations, refundNode];
-    });
-  }
-
-  /**
-   * Returns a JSON object required by the callback function of webtask to modifify the program.
-   */
-  toJson() {
-    return {
-      mutations: this.mutations,
-      programId: this.context.body.program.id,
-      analytics: this.analytics,
-    };
-  }
+ /**
+  * Returns a JSON object required by the callback function of webtask to modifify the program.
+  */
+ toJson() {
+  return {
+   mutations: this.mutations,
+   programId: this.context.body.program.id,
+   analytics: this.analytics,
+  };
+ }
 }

--- a/packages/program-boilerplate/src/transaction.ts
+++ b/packages/program-boilerplate/src/transaction.ts
@@ -174,8 +174,8 @@ export default class Transaction {
       key: rewardKey,
       rewardId: rewardId,
       referralId: referralId,
-      dynamicProperties,
-      overrideProperties
+      overrideProperties,
+      dynamicProperties
     };
 
     const validProperties = [
@@ -302,14 +302,16 @@ export default class Transaction {
     referralId,
     user,
     status,
-    rewardProperties,
+    overrideProperties,
+    dynamicProperties
   }: {
     emailKey: string;
     rewardKey: string;
     referralId: string;
     user: User;
     status?: string;
-    rewardProperties?: any;
+    overrideProperties?: any;
+    dynamicProperties?: any;
   }) {
     const {rewardId} = this.generateReferralReward({
       rewardKey,
@@ -318,7 +320,8 @@ export default class Transaction {
       userEvent: undefined,
       rewardSource: undefined,
       status,
-      rewardProperties,
+      overrideProperties,
+      dynamicProperties
     });
 
     this.generateReferralEmail({emailKey, user, referralId, rewardId});

--- a/packages/program-boilerplate/src/transaction.ts
+++ b/packages/program-boilerplate/src/transaction.ts
@@ -88,6 +88,7 @@ export default class Transaction {
    * @param {string} analyticsKey      type of goal achieved
    * @param {string} analyticsDedupeId dedupe id of the analytic event
    * @param {number} timestamp         timestamp of the event
+   * @param {boolean} isConversion     whether the analytic should convert the referral
    */
   fireProgramGoalAnalytics(
     user: User,
@@ -95,6 +96,7 @@ export default class Transaction {
     analyticsKey: string,
     analyticsDedupeId: string | null,
     timestamp: number,
+    isConversion: boolean = true
   ) {
     const goalAnalytic = {
       eventType: 'PROGRAM_GOAL',
@@ -107,6 +109,7 @@ export default class Transaction {
           id: user.id,
           accountId: user.accountId,
         },
+        isConversion
       },
     };
 

--- a/packages/program-boilerplate/src/transaction.ts
+++ b/packages/program-boilerplate/src/transaction.ts
@@ -249,6 +249,7 @@ export default class Transaction {
           id: user.id,
           accountId: user.accountId,
         },
+        rewardId,
         key: emailKey,
         queryVariables: queryVariables,
         query: rewardId

--- a/packages/program-boilerplate/src/transaction.ts
+++ b/packages/program-boilerplate/src/transaction.ts
@@ -89,7 +89,7 @@ export default class Transaction {
     user: User,
     programType: ProgramType,
     analyticsKey: string,
-    analyticsDedupeId: string,
+    analyticsDedupeId: string | null,
     timestamp: number,
   ) {
     const goalAnalytic = {

--- a/packages/program-boilerplate/src/transaction.ts
+++ b/packages/program-boilerplate/src/transaction.ts
@@ -25,6 +25,13 @@ type ReferralRewardInput = {
     dateScheduledFor?: number | null;
     dateExpires?: number | null;
   };
+  dynamicProperties?: {
+    dateScheduledFor?: number | null;
+    dateExpires?: number | null;
+    type: string;
+    unit: string;
+    assignedCredit: number;
+  };
 };
 
 export default class Transaction {
@@ -154,7 +161,8 @@ export default class Transaction {
       userEvent,
       rewardSource,
       status,
-      rewardProperties,
+      overrideProperties,
+      dynamicProperties,
     } = input;
 
     const rewardId = ObjectID.generate();
@@ -172,7 +180,8 @@ export default class Transaction {
       {userEvent},
       {rewardSource},
       {status},
-      rewardProperties,
+      dynamicProperties,
+      overrideProperties
     ].filter((prop) => prop !== undefined);
     const updatedRewardData = validProperties.reduce((currentData, prop) => {
       return {...currentData, ...prop};

--- a/packages/program-boilerplate/src/transaction.ts
+++ b/packages/program-boilerplate/src/transaction.ts
@@ -21,6 +21,10 @@ type ReferralRewardInput = {
   rewardSource?: string;
   status?: string;
   rewardProperties?: any;
+  overrideProperties?: {
+    dateScheduledFor?: number | null;
+    dateExpires?: number | null;
+  };
 };
 
 export default class Transaction {

--- a/packages/program-boilerplate/src/transaction.ts
+++ b/packages/program-boilerplate/src/transaction.ts
@@ -174,18 +174,19 @@ export default class Transaction {
       key: rewardKey,
       rewardId: rewardId,
       referralId: referralId,
+      dynamicProperties,
+      overrideProperties
     };
 
     const validProperties = [
       {userEvent},
       {rewardSource},
       {status},
-      dynamicProperties,
-      overrideProperties
     ].filter((prop) => prop !== undefined);
     const updatedRewardData = validProperties.reduce((currentData, prop) => {
       return {...currentData, ...prop};
     }, rewardData);
+
     const newMutation = {
       type: 'CREATE_REWARD',
       data: updatedRewardData,

--- a/packages/program-boilerplate/src/utils.ts
+++ b/packages/program-boilerplate/src/utils.ts
@@ -1,7 +1,7 @@
-import {rewardScheduleQuery} from './queries';
-import {ProgramTriggerBody, TriggerType} from './types/rpc';
-import {User} from './types/saasquatch';
-import {loggers} from 'winston';
+import { rewardScheduleQuery } from "./queries";
+import { ProgramTriggerBody, TriggerType } from "./types/rpc";
+import { User } from "./types/saasquatch";
+import { loggers } from "winston";
 
 /**
  * Append a reward schedule to the template and return the new template
@@ -13,41 +13,41 @@ import {loggers} from 'winston';
  * @param {number} periodInHours     The refresh period
  */
 export function setRewardSchedule({
-  template,
-  expiryWarningDays,
-  key,
-  emailKey,
-  periodInHours,
+	template,
+	expiryWarningDays,
+	key,
+	emailKey,
+	periodInHours,
 }: {
-  template: any;
-  expiryWarningDays: number;
-  key: string;
-  emailKey: string;
-  periodInHours: number;
+	template: any;
+	expiryWarningDays: number;
+	key: string;
+	emailKey: string;
+	periodInHours: number;
 }): any {
-  if (expiryWarningDays) {
-    const dateExpires_timeframe = `next_${expiryWarningDays}_days`;
-    const rewardSchedule = {
-      key,
-      type: 'REWARD',
-      filter: {
-        dateExpires_timeframe,
-      },
-      query: rewardScheduleQuery(emailKey),
-      periodInHours,
-    };
-    const currentSchedules = template.schedules;
-    const schedules = currentSchedules
-      ? [...currentSchedules, rewardSchedule]
-      : [rewardSchedule];
-    const newTemplate = {
-      ...template,
-      schedules,
-    };
-    return newTemplate;
-  } else {
-    return template;
-  }
+	if (expiryWarningDays) {
+		const dateExpires_timeframe = `next_${expiryWarningDays}_days`;
+		const rewardSchedule = {
+			key,
+			type: "REWARD",
+			filter: {
+				dateExpires_timeframe,
+			},
+			query: rewardScheduleQuery(emailKey),
+			periodInHours,
+		};
+		const currentSchedules = template.schedules;
+		const schedules = currentSchedules
+			? [...currentSchedules, rewardSchedule]
+			: [rewardSchedule];
+		const newTemplate = {
+			...template,
+			schedules,
+		};
+		return newTemplate;
+	} else {
+		return template;
+	}
 }
 
 /**
@@ -61,11 +61,11 @@ export function setRewardSchedule({
  * @return {number} The timestamp
  */
 export function getGoalAnalyticTimestamp(trigger: any): number {
-  const purchaseEvent = trigger.events
-    ? trigger.events.find((e: any) => e.key === 'purchase')
-    : undefined;
+	const purchaseEvent = trigger.events
+		? trigger.events.find((e: any) => e.key === "purchase")
+		: undefined;
 
-  return purchaseEvent ? purchaseEvent.dateTriggered - 1 : trigger.time;
+	return purchaseEvent ? purchaseEvent.dateTriggered - 1 : trigger.time;
 }
 
 /**
@@ -85,37 +85,53 @@ export function getGoalAnalyticTimestamp(trigger: any): number {
  * NaN => NaN (number)
  * @example
  * undefined => undefined
+ * @example
+ * "[true, false]" => [true, false] (object)
+ * @example
+ * "{"key1":true,"key2":false}" => {"key1":true,"key2":false} (object)
+ * @example
  *
  * @param {string} val The value to test
  * @return {any} the computed value
  */
 export function inferType(val: string): any {
-  if (/^(-|\+)?([0-9]+(\.[0-9]+)?)$/.test(val)) {
-    const asNum = Number(val);
+	if (/^(-|\+)?([0-9]+(\.[0-9]+)?)$/.test(val)) {
+		const asNum = Number(val);
 
-    if (!isNaN(asNum)) {
-      return asNum;
-    }
-  }
+		if (!isNaN(asNum)) {
+			return asNum;
+		}
+	}
 
-  switch (val) {
-    case 'undefined':
-      return undefined;
-    case 'null':
-      return null;
-    case 'NaN':
-      return NaN;
-    case 'Infinity':
-      return Infinity;
-    case '-Infinity':
-      return -Infinity;
-    case 'true':
-      return true;
-    case 'false':
-      return false;
-    default:
-      return val;
-  }
+	if (/(^[\[].*[\]]$)|(^[\{].*[\}]$)/.test(val)) {
+		try {
+			const asObject = JSON.parse(val);
+			if (asObject instanceof Object) {
+				return asObject;
+			}
+		} catch (e) {
+			return undefined;
+		}
+	}
+
+	switch (val) {
+		case "undefined":
+			return undefined;
+		case "null":
+			return null;
+		case "NaN":
+			return NaN;
+		case "Infinity":
+			return Infinity;
+		case "-Infinity":
+			return -Infinity;
+		case "true":
+			return true;
+		case "false":
+			return false;
+		default:
+			return val;
+	}
 }
 
 /**
@@ -125,16 +141,16 @@ export function inferType(val: string): any {
  * @return {string} the string representation of the conversion operator
  */
 export function numToEquality(num: number): string {
-  switch (num) {
-    case 0:
-      return 'eq';
-    case 1:
-      return 'gte';
-    case 2:
-      return 'lte';
-    default:
-      return 'eq';
-  }
+	switch (num) {
+		case 0:
+			return "eq";
+		case 1:
+			return "gte";
+		case 2:
+			return "lte";
+		default:
+			return "eq";
+	}
 }
 
 /**
@@ -143,55 +159,55 @@ export function numToEquality(num: number): string {
  * @return object[] The tranformed data that is relavent for the trigger type
  */
 export function getTriggerSchema(body: ProgramTriggerBody): object[] {
-  const activeTrigger = body.activeTrigger;
-  const triggerType = activeTrigger.type as TriggerType;
-  const standardData = {
-    type: activeTrigger.type,
-    time: activeTrigger.time,
-    user: activeTrigger.user,
-  };
-  switch (triggerType) {
-    case 'AFTER_USER_CREATED_OR_UPDATED':
-      return [
-        {
-          ...standardData,
-          previous: activeTrigger.previous,
-        },
-      ];
-    case 'REFERRAL':
-      return [
-        {
-          ...standardData,
-          referral: activeTrigger.referral,
-        },
-      ];
-    case 'AFTER_USER_EVENT_PROCESSED':
-      let contexts: object[] = [];
-      activeTrigger.events.forEach((event: any) => {
-        contexts.push({
-          ...standardData,
-          event: {
-            key: event.key,
-            id: event.id,
-            dateTriggered: event.dateTriggered,
-            fields: event.fields,
-          },
-        });
-      });
-      return contexts;
-    case 'SCHEDULED':
-      return [
-        {
-          ...standardData,
-        },
-      ];
-    case 'REWARD_SCHEDULED':
-      return [
-        {
-          ...standardData,
-        },
-      ];
-    default:
-      throw new Error('Trigger type did not match expected options');
-  }
+	const activeTrigger = body.activeTrigger;
+	const triggerType = activeTrigger.type as TriggerType;
+	const standardData = {
+		type: activeTrigger.type,
+		time: activeTrigger.time,
+		user: activeTrigger.user,
+	};
+	switch (triggerType) {
+		case "AFTER_USER_CREATED_OR_UPDATED":
+			return [
+				{
+					...standardData,
+					previous: activeTrigger.previous,
+				},
+			];
+		case "REFERRAL":
+			return [
+				{
+					...standardData,
+					referral: activeTrigger.referral,
+				},
+			];
+		case "AFTER_USER_EVENT_PROCESSED":
+			let contexts: object[] = [];
+			activeTrigger.events.forEach((event: any) => {
+				contexts.push({
+					...standardData,
+					event: {
+						key: event.key,
+						id: event.id,
+						dateTriggered: event.dateTriggered,
+						fields: event.fields,
+					},
+				});
+			});
+			return contexts;
+		case "SCHEDULED":
+			return [
+				{
+					...standardData,
+				},
+			];
+		case "REWARD_SCHEDULED":
+			return [
+				{
+					...standardData,
+				},
+			];
+		default:
+			throw new Error("Trigger type did not match expected options");
+	}
 }


### PR DESCRIPTION
## Description of the change

> - The `rewardId` for an email was not being appropriately set on the data in the `SEND_EMAIL` mutation
> - We need to support null `dedupeIds` on program analytics for new `programObjectives` feature on users

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

 - Jira issue number: DEV-2932
 - Process.st launch checklist: (PUT IT HERE)

## Checklists

### Development

- [ ] [Prettier](https://www.npmjs.com/package/prettier) was run
- [ ] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist
- [ ] "Ready for review" label attached to the PR and reviewers pinged on Slack

### Code review 

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
