### PR TITLE
DEV-3044: Add validation for new salesforce submit action case to Jsonata editors

### DIFF
--- a/packages/visual-dev/package-lock.json
+++ b/packages/visual-dev/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/visual-dev",
-  "version": "0.2.0",
+  "version": "0.2.1-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/visual-dev/package.json
+++ b/packages/visual-dev/package.json
@@ -1,10 +1,12 @@
 {
   "name": "@saasquatch/visual-dev",
-  "version": "0.2.1-1",
+  "version": "0.2.1-2",
   "description": "SaaSquatch visual dev",
   "main": "dist/index.js",
   "module": "dist/index.js",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "lint": "standard",
@@ -58,11 +60,23 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "jsdom",
-    "testPathIgnorePatterns": ["dist/"]
+    "testPathIgnorePatterns": [
+      "dist/"
+    ]
   },
   "standard": {
-    "ignore": ["node_modules/", "dist/"],
-    "globals": ["describe", "it", "test", "expect", "afterAll", "jest"]
+    "ignore": [
+      "node_modules/",
+      "dist/"
+    ],
+    "globals": [
+      "describe",
+      "it",
+      "test",
+      "expect",
+      "afterAll",
+      "jest"
+    ]
   },
   "repository": {
     "type": "git",

--- a/packages/visual-dev/package.json
+++ b/packages/visual-dev/package.json
@@ -4,16 +4,13 @@
   "description": "SaaSquatch visual dev",
   "main": "dist/index.js",
   "module": "dist/index.js",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsc",
     "lint": "standard",
     "format": "prettier-standard --format",
     "test": "echo test",
-    "storybook": "start-storybook",
-    "prebuild": "npm run lint && npm run format"
+    "storybook": "start-storybook"
   },
   "keywords": [],
   "author": "SaaSquatch Team",
@@ -61,23 +58,11 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "jsdom",
-    "testPathIgnorePatterns": [
-      "dist/"
-    ]
+    "testPathIgnorePatterns": ["dist/"]
   },
   "standard": {
-    "ignore": [
-      "node_modules/",
-      "dist/"
-    ],
-    "globals": [
-      "describe",
-      "it",
-      "test",
-      "expect",
-      "afterAll",
-      "jest"
-    ]
+    "ignore": ["node_modules/", "dist/"],
+    "globals": ["describe", "it", "test", "expect", "afterAll", "jest"]
   },
   "repository": {
     "type": "git",

--- a/packages/visual-dev/package.json
+++ b/packages/visual-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/visual-dev",
-  "version": "0.2.0",
+  "version": "0.2.1-1",
   "description": "SaaSquatch visual dev",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/visual-dev/src/components/JSONata/JSONataUtils.tsx
+++ b/packages/visual-dev/src/components/JSONata/JSONataUtils.tsx
@@ -3,41 +3,42 @@ import { JsonataASTNode } from "jsonata-ui-core";
 import jsonata, { ExprNode } from "jsonata";
 
 const JSONataUtils = {
-
-  getKeys(value:ExprNode, props:any) {
-    const {isCustomField, conversionRule} = props;
+  getKeys(value: ExprNode, props: any) {
+    const { isCustomField, conversionRule } = props;
     try {
-      const keys = !isCustomField &&
-      conversionRule !== "referral" &&
-      value &&
-      jsonata(
+      const keys =
+        !isCustomField &&
+        conversionRule !== "referral" &&
+        value &&
+        jsonata(
           `[**[type="binary" 
       and value = "="
       and lhs.type = "path" 
       and lhs.steps[type="name"].value=["event","key"]
       ].rhs[type="string"].value ~> $distinct()]`
-      ).evaluate(value);
+        ).evaluate(value);
       return keys;
-    } catch (error){
+    } catch (error) {
       return null;
     }
-
   },
 
   isValidBasicExpression(newValue: AST): string | null {
     const NodeWhitelist = jsonata(`**[type = "function"]`);
+    const unaryWithCondition = jsonata(`type = "unary" and lhs`);
     try {
-      if(NodeWhitelist.evaluate(newValue)) {
-        return "Functions are not allowed in basic mode."
-      } 
+      if (NodeWhitelist.evaluate(newValue)) {
+        return "Functions are not allowed in basic mode.";
+      } else if (unaryWithCondition.evaluate(newValue)) {
+        return "Object mappings with conditions are not allowed in basic mode.";
+      }
     } catch (e) {}
     return null;
   },
-  
+
   containsRootLevelSelect(value: string) {
     const re = /([:( =><]|^)select([ =><.?!)]|$)(?=(?:[^"]*"[^"]*")*[^"]*$)/;
     return re.test(value);
-  
   },
 
   addRule(currentChildren: ConditionEditorProps["children"]) {
@@ -49,8 +50,8 @@ const JSONataUtils = {
       else: {
         type: "condition",
         condition: newCondition,
-        then: newTier
-      }
+        then: newTier,
+      },
     } as JsonataASTNode;
 
     lastChild.onChange(newAst as JsonataASTNode);
@@ -61,11 +62,11 @@ const JSONataUtils = {
     children: ConditionEditorProps["children"],
     elseEditor?: ConditionEditorProps["elseEditor"]
   ) {
-    children.forEach(child => {
+    children.forEach((child) => {
       if (pair.Then.props.ast.value === child.Then.props.ast.value) return;
     });
-    if(elseEditor) elseEditor.props.ast.value = null;
-  }
-}
+    if (elseEditor) elseEditor.props.ast.value = null;
+  },
+};
 
 export default JSONataUtils;

--- a/packages/visual-dev/src/components/Typography.tsx
+++ b/packages/visual-dev/src/components/Typography.tsx
@@ -46,11 +46,11 @@ export const H3 = styled.h3<H3Props>`
   line-height: 13px;
   font-weight: 600;
   font-size: 13px;
-  margin-bottom: ${(props) => props.noMargin ? '0' : `8px`};
-  ${(props) => props.noMargin && 'margin: 0'};
+  margin-bottom: ${(props) => (props.noMargin ? "0" : `8px`)};
+  ${(props) => props.noMargin && "margin: 0"};
 `;
 
-export const P = styled.p<{ bold?: boolean, noMargin?: boolean }>`
+export const P = styled.p<{ bold?: boolean; noMargin?: boolean }>`
   font-family: "Helvetica Neue", Helvetica, sans-serif;
   font-size: 13px;
   color: ${(props) => props.color || `#575757`};
@@ -74,12 +74,12 @@ export const NumberedStep = styled.div`
 export const AttributeHeading = styled.h3`
   font-family: "Helvetica Neue", Helvetica, sans-serif;
   color: #808080;
-  font-weight: normal
+  font-weight: normal;
   font-size: 12px;
   line-height: 14px;
   margin: 0px;
   padding: 0px;
-`
+`;
 
 export const WidgetTitle = styled.h2`
   font-family: "Helvetica Neue", Helvetica, sans-serif;
@@ -89,9 +89,9 @@ export const WidgetTitle = styled.h2`
   line-height: 16px;
   margin: 0px;
   padding: 0px;
-`
+`;
 
-export const ErrorBlock = styled(P)<{margin?: string}>`
+export const ErrorBlock = styled(P)<{ margin?: string }>`
   color: #f92929;
   margin: ${(props) => props.margin || `0px`};
-`
+`;


### PR DESCRIPTION
## Description of the change

Add validation so that something like ` {"test": data.lastName ? data.lastName : user.lastName}` does not blow up the salesforce submit action field mapping jsonata editor

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

 - Jira issue number: DEV-3044
 - Process.st launch checklist: https://app.process.st/checklists/DEV-3044-Update-visual-dev-jsonata-editor-validation-for-Salesforce-frontend1-hbRumLw2P3Gwrvv56pVH5g

## Checklists

### Development

- [x] [Prettier](https://www.npmjs.com/package/prettier) was run
- [ ] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has a Jira number
- [x] This pull request has a Process.st launch checklist
- [ ] "Ready for review" label attached to the PR and reviewers pinged on Slack

### Code review 

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
