### PR TITLE
DEV-3165: Fix payload too large Error

### DIFF
--- a/packages/program-boilerplate/package.json
+++ b/packages/program-boilerplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.5.9",
+  "version": "3.5.10",
   "description": "Boilerplate for writing programs",
   "main": "dist/index.js",
   "files": [
@@ -32,7 +32,6 @@
     "typescript": "^3.9.9"
   },
   "dependencies": {
-    "body-parser": "^1.19.0",
     "bson-objectid": "^1.3.1",
     "compression": "^1.7.4",
     "express": "^4.17.1",

--- a/packages/program-boilerplate/src/index.ts
+++ b/packages/program-boilerplate/src/index.ts
@@ -60,12 +60,11 @@ export {
  * @return {Object} The express server
  */
 export function webtask(program: Program = {}): express.Application {
-  const bodyParser = require("body-parser");
   const compression = require("compression");
 
   const app = express();
 
-  app.use(bodyParser.json());
+  app.use(express.json({ limit: process.env.MAX_PAYLOAD_SIZE || "1mb" }));
   app.use(compression());
 
   // Enforce HTTPS. The server does not redirect http -> https


### PR DESCRIPTION
## Description of the change

Set default payload size limit to 1mb, and add env var for easier customization.
Bump version.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

 - Jira issue number: [DEV-3165](https://saasquatch.atlassian.net/browse/DEV-3165)
 - Process.st launch checklist: [HERE](https://app.process.st/runs/DEV-3165-Program-boilerplate-payload-too-large-error-h5wVw0ixHtvpIC2GhxFHNw/tasks/ipJPSwLUytFe3xMt6P5PYw)

## Checklists

### Development

- [x] [Prettier](https://www.npmjs.com/package/prettier) was run
- [ ] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has a Jira number
- [x] This pull request has a Process.st launch checklist
- [x] "Ready for review" label attached to the PR and reviewers pinged on Slack

### Code review 

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
