### PR TITLE
Error warnings for GrapesJS Stencil Plugin

### DIFF
--- a/packages/stencil-grapes-plugin/CHANGELOG.md
+++ b/packages/stencil-grapes-plugin/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] - 2021-12-23
+
+### Added
+
+- Throws helpful errors for invalid JSON
+
 ## [1.0.1] - 2021-06-23
 
 ### Added

--- a/packages/stencil-grapes-plugin/CHANGELOG.md
+++ b/packages/stencil-grapes-plugin/CHANGELOG.md
@@ -32,7 +32,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - @uiEnum
     - @uiEnumNames
     - @uiType
-
-[unreleased]: https://github.com/saasquatch/freshest-themes/compare/servicetitan-components@1.0.1...HEAD
-[1.0.1]: https://github.com/saasquatch/freshest-themes/releases/tag/servicetitan-components@1.0.1
-[1.0.0]: https://github.com/saasquatch/freshest-themes/releases/tag/servicetitan-components@1.0.0

--- a/packages/stencil-grapes-plugin/example/package-lock.json
+++ b/packages/stencil-grapes-plugin/example/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grapes-test",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/stencil-grapes-plugin/package-lock.json
+++ b/packages/stencil-grapes-plugin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/stencil-grapes-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/stencil-grapes-plugin/package-lock.json
+++ b/packages/stencil-grapes-plugin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/stencil-grapes-plugin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/stencil-grapes-plugin/package.json
+++ b/packages/stencil-grapes-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/stencil-grapes-plugin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A stencil docs generator for generating GrapesJS plugins",
   "source": "src/generator.ts",
   "main": "dist/generator.js",


### PR DESCRIPTION
The grapesJS stencil plugin expects some fields to be in JSON format. When there is an error, it is hard to track down where that comes from.

This patch adds error catch-and-rethrow to help developers track down their malformed comments.