### PR TITLE
[DEV-3181] Clara icon fix

### DIFF
--- a/packages/mint-components/CHANGELOG.md
+++ b/packages/mint-components/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2021-01-10
+
+### Fixed
+
+- Fixed broken WhatsApp icon by updating the version of bootstrap icons from 1.2.0 to 1.7.2
+
 ## [1.4.0] - 2021-12-09
 
 - Updated version of component-boilerplate to prevent rare case of user context being deleted during register

--- a/packages/mint-components/CHANGELOG.md
+++ b/packages/mint-components/CHANGELOG.md
@@ -188,7 +188,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - \<sqm-popup-container>
   - \<sqm-stencilbook>
 
-[unreleased]: https://github.com/saasquatch/program-tools/compare/mint-components@1.4.0...HEAD
+[unreleased]: https://github.com/saasquatch/program-tools/compare/mint-components@1.4.1...HEAD
+[1.4.1]: https://github.com/saasquatch/program-tools/releases/tag/%40saasquatch%2Fmint-components%401.4.1
 [1.4.0]: https://github.com/saasquatch/program-tools/releases/tag/%40saasquatch%2Fmint-components%401.4.0
 [1.3.0]: https://github.com/saasquatch/program-tools/releases/tag/%40saasquatch%2Fmint-components%401.3.0
 [1.2.0]: https://github.com/saasquatch/program-tools/releases/tag/%40saasquatch%2Fmint-components%401.2.0

--- a/packages/mint-components/CHANGELOG.md
+++ b/packages/mint-components/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.4.1] - 2021-01-10
+## [1.4.1] - 2021-01-17
 
 ### Fixed
 

--- a/packages/mint-components/package.json
+++ b/packages/mint-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/mint-components",
-  "version": "1.4.1-0",
+  "version": "1.4.1",
   "description": "Mint Components - Built with Shoelace Components",
   "main": "dist/index.cjs.js",
   "es2015": "dist/esm/index.js",

--- a/packages/mint-components/package.json
+++ b/packages/mint-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/mint-components",
-  "version": "1.4.0",
+  "version": "1.4.1-0",
   "description": "Mint Components - Built with Shoelace Components",
   "main": "dist/index.cjs.js",
   "es2015": "dist/esm/index.js",

--- a/packages/mint-components/src/global/global.ts
+++ b/packages/mint-components/src/global/global.ts
@@ -74,7 +74,7 @@ try {
   registerIconLibrary("default", {
     // same link that shoelace uses internally
     resolver: (name) =>
-      `https://fast.ssqt.io/npm/bootstrap-icons@1.2.0/icons/${name}.svg`,
+      `https://fast.ssqt.io/npm/bootstrap-icons@1.7.2/icons/${name}.svg`,
   });
   // SlAlert.register();
   customElements.define("sl-alert", SlAlert);

--- a/packages/mint-components/src/stories/ShareButton.stories.tsx
+++ b/packages/mint-components/src/stories/ShareButton.stories.tsx
@@ -87,6 +87,14 @@ export const AllMediums = () => {
       <sqm-share-button medium="fbmessenger" icon="messenger" iconslot="prefix">
         <span>Messenger</span>
       </sqm-share-button>
+      <br />
+      <sqm-share-button medium="sms" icon="chat" iconslot="prefix">
+        <span>SMS</span>
+      </sqm-share-button>
+      <br />
+      <sqm-share-button medium="linemessenger" icon="line" iconslot="prefix">
+        <span>Line Messenger</span>
+      </sqm-share-button>
     </div>
   );
 };

--- a/packages/mint-components/src/stories/ShareButton.stories.tsx
+++ b/packages/mint-components/src/stories/ShareButton.stories.tsx
@@ -56,3 +56,37 @@ export const FullStackIcon = () => {
     </div>
   );
 };
+
+export const AllMediums = () => {
+  return (
+    <div>
+      <sqm-share-button medium="facebook" iconslot="prefix">
+        <span>Facebook</span>
+      </sqm-share-button>
+      <br />
+      <sqm-share-button medium="email" icon="envelope" iconslot="prefix">
+        <span>Email</span>
+      </sqm-share-button>
+      <br />
+      <sqm-share-button medium="whatsapp" icon="whatsapp" iconslot="prefix">
+        <span>WhatsApp</span>
+      </sqm-share-button>
+      <br />
+      <sqm-share-button medium="linkedin" iconslot="prefix">
+        <span>Linkedin</span>
+      </sqm-share-button>
+      <br />
+      <sqm-share-button medium="twitter" iconslot="prefix">
+        <span>Twitter</span>
+      </sqm-share-button>
+      <br />
+      <sqm-share-button medium="pinterest" iconslot="prefix">
+        <span>Pinterest</span>
+      </sqm-share-button>
+      <br />
+      <sqm-share-button medium="fbmessenger" icon="messenger" iconslot="prefix">
+        <span>Messenger</span>
+      </sqm-share-button>
+    </div>
+  );
+};

--- a/packages/mint-components/src/stories/ShareButton.stories.tsx
+++ b/packages/mint-components/src/stories/ShareButton.stories.tsx
@@ -6,7 +6,7 @@ export default {
 };
 
 export const WithIcon = () => {
-  const props = { medium: "facebook", iconslot: "suffix" } as const;
+  const props = { medium: "whatsapp", iconslot: "suffix" } as const;
   return <ShareButtonView {...props}>Share</ShareButtonView>;
 };
 


### PR DESCRIPTION
## Description of the change

> Updated the outdated version of bootstrap-icons which was causing the WhatsApp icon to break. 

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

 - Jira issue number: https://saasquatch.atlassian.net/browse/DEV-3181
 - Process.st launch checklist: https://app.process.st/runs/DEV-3181-Clara-icon-bug-fix-houyOxGEo98wE8cFTSBNUQ
 - Coda: https://coda.io/d/Clara-Icon-Fix_dj6a2LgN7HK/Scope_su9PA#_lucIQ
 - Stencilbook: https://mint-components.stencilbook.saasquat.ch/pr246/index.html

## Checklists

### Development

- [X] [Prettier](https://www.npmjs.com/package/prettier) was run
- [ ] The behaviour changes in the pull request are covered by specs
- [x] All tests related to the changed code pass in development

### Paperwork

- [X] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist
- [X] "Ready for review" label attached to the PR and reviewers pinged on Slack

### Code review 

- [x] Changes have been reviewed by at least one other engineer
- [x] Security impacts of this change have been considered
