### PR TITLE
[DEV-3188] integration-boilerplate-node: getIntegrationTenants and default router

### DIFF
--- a/packages/integration-boilerplate-node/CHANGELOG.md
+++ b/packages/integration-boilerplate-node/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `getIntegrationTenants` service method to return a list of all tenant aliases
   that have the integration enabled.
+- A router for custom endpoints is always created, and is accessible as `service.router`,
+  however the `customRouter` option still works for backwards compatibility.
 
 ## [1.0.0] - 2021-08-13
 

--- a/packages/integration-boilerplate-node/CHANGELOG.md
+++ b/packages/integration-boilerplate-node/CHANGELOG.md
@@ -7,11 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2022-01-27
+
+### Added
+
+- `getIntegrationTenants` service method to return a list of all tenant aliases
+  that have the integration enabled.
+
 ## [1.0.0] - 2021-08-13
 
 ### Added
 
 - Initial release
 
-[unreleased]: https://github.com/sasquatch/integration-boilerplate-node/compare/v1.0.0...HEAD
+[unreleased]: https://github.com/sasquatch/integration-boilerplate-node/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/sasquatch/integration-boilerplate-node/releases/tag/v1.1.0
 [1.0.0]: https://github.com/sasquatch/integration-boilerplate-node/releases/tag/v1.0.0

--- a/packages/integration-boilerplate-node/README.md
+++ b/packages/integration-boilerplate-node/README.md
@@ -190,7 +190,6 @@ and middleware as needed.
 import { createIntegrationService } from "@saasquatch/integration-boilerplate-node";
 
 async function main() {
-  const router = Router();
   const service = await createIntegrationService();
 
   service.router.get("/myCustomRoute", (req, res) => {

--- a/packages/integration-boilerplate-node/README.md
+++ b/packages/integration-boilerplate-node/README.md
@@ -183,19 +183,17 @@ kind of data.
 Many integrations can get away with only providing handlers for webhooks and forms, however more complex integrations
 that may respond to webhooks from 3rd party systems need to define their own routing and middleware.
 
-This is achievable by providing an `express.Router` to the `customRouter` option when creating the service:
+There is a router available on the service as `service.router` for this purpose, which can be configured with routes
+and middleware as needed.
 
 ```ts
-import { Router } from "express";
 import { createIntegrationService } from "@saasquatch/integration-boilerplate-node";
 
 async function main() {
   const router = Router();
-  const service = await createIntegrationService({
-    customRouter: router,
-  });
+  const service = await createIntegrationService();
 
-  router.get("/myCustomRoute", (req, res) => {
+  service.router.get("/myCustomRoute", (req, res) => {
     res.send("Hello World");
   });
 

--- a/packages/integration-boilerplate-node/package-lock.json
+++ b/packages/integration-boilerplate-node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/integration-boilerplate-node",
-  "version": "1.0.0",
+  "version": "1.1.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/integration-boilerplate-node/package-lock.json
+++ b/packages/integration-boilerplate-node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/integration-boilerplate-node",
-  "version": "1.1.0-1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/integration-boilerplate-node/package-lock.json
+++ b/packages/integration-boilerplate-node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/integration-boilerplate-node",
-  "version": "1.1.0-0",
+  "version": "1.1.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/integration-boilerplate-node/package.json
+++ b/packages/integration-boilerplate-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/integration-boilerplate-node",
-  "version": "1.0.0",
+  "version": "1.1.0-0",
   "description": "Node/Express boilerplate for building SaaSquatch integrations",
   "engines": {
     "node": "^14"

--- a/packages/integration-boilerplate-node/package.json
+++ b/packages/integration-boilerplate-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/integration-boilerplate-node",
-  "version": "1.1.0-0",
+  "version": "1.1.0-1",
   "description": "Node/Express boilerplate for building SaaSquatch integrations",
   "engines": {
     "node": "^14"

--- a/packages/integration-boilerplate-node/package.json
+++ b/packages/integration-boilerplate-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/integration-boilerplate-node",
-  "version": "1.1.0-1",
+  "version": "1.1.0",
   "description": "Node/Express boilerplate for building SaaSquatch integrations",
   "engines": {
     "node": "^14"

--- a/packages/integration-boilerplate-node/src/service.ts
+++ b/packages/integration-boilerplate-node/src/service.ts
@@ -89,6 +89,7 @@ export class IntegrationService<
   readonly tenantScopedTokenMiddleware: ReturnType<
     typeof createSaasquatchTokenMiddleware
   >;
+  readonly router: Router;
 
   private server: Express;
   private tenantIntegrationConfigCache: NodeCache;
@@ -111,6 +112,7 @@ export class IntegrationService<
       this.auth,
       this.logger
     );
+    this.router = options?.customRouter || Router();
     this.server = this.createExpressServer();
     this.tenantIntegrationConfigCache = new NodeCache({
       stdTTL: 60,
@@ -329,9 +331,7 @@ export class IntegrationService<
       );
     });
 
-    if (this.options?.customRouter) {
-      server.use("/", this.options.customRouter);
-    }
+    server.use("/", this.router);
 
     // Serve the frontend at the root of the server
     if (this.config.proxyFrontend) {


### PR DESCRIPTION
## Description of the change

Adds a `getIntegrationTenants` method to the service to get a list of all tenant aliases that have the integration enabled.

Adds a default custom router to the service to improve setup experience.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

 - Jira issue number: DEV-3188
 - Process.st launch checklist: https://app.process.st/runs/DEV-3188-SFTP-Import-Integration-koCSVi-DDB9cLOiHiKZN9w

## Checklists

### Development

- [x] [Prettier](https://www.npmjs.com/package/prettier) was run
- [x] The behaviour changes in the pull request are covered by specs
- [x] All tests related to the changed code pass in development

### Paperwork

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has a Jira number
- [x] This pull request has a Process.st launch checklist

### Code review 

- [x] Changes have been reviewed by at least one other engineer
- [x] Security impacts of this change have been considered
