### PR TITLE
IH: remove sqm-graphql-client-provider from templates

### DIFF
--- a/packages/mint-components/CHANGELOG.md
+++ b/packages/mint-components/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - clear success message on re-send
 - \<sqm-portal-reset-password>
   - handle network failure of reset password mutation
+- removed sqm-graphql-client-provider usage from portal templates
 
 ## [1.5.5] - 2022-04-21
 

--- a/packages/mint-components/src/templates/EditProfile.html
+++ b/packages/mint-components/src/templates/EditProfile.html
@@ -6,7 +6,5 @@
 <sqm-portal-container direction="column" gap="xxx-large">
   <sqm-portal-profile></sqm-portal-profile> </sqm-portal-container
 ><sqm-portal-container direction="column" gap="xxx-large">
-  <sqm-graphql-client-provider domain="https://managed-identity.saasquatch.com">
-    <sqm-portal-change-password></sqm-portal-change-password>
-  </sqm-graphql-client-provider>
+  <sqm-portal-change-password></sqm-portal-change-password>
 </sqm-portal-container>

--- a/packages/mint-components/src/templates/MultiProgramPortal.html
+++ b/packages/mint-components/src/templates/MultiProgramPortal.html
@@ -12,51 +12,47 @@
       <template
         path="/:path(\bregister\b|\bemailVerification\b|\blogin\b|\bverifyEmail\b|\bforgotPassword\b|\bresetPassword\b|\blogout\b)"
       >
-        <sqm-graphql-client-provider
-          domain="https://managed-identity.saasquatch.com"
+        <sqm-hero
+          background="https://images.unsplash.com/photo-1599676821464-3555954838dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1939&q=80"
         >
-          <sqm-hero
-            background="https://images.unsplash.com/photo-1599676821464-3555954838dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1939&q=80"
-          >
-            <sqm-router>
-              <template path="/register">
-                <sqm-portal-register>
-                  <sqm-name-fields slot="formData"></sqm-name-fields>
-                </sqm-portal-register>
-              </template>
+          <sqm-router>
+            <template path="/register">
+              <sqm-portal-register>
+                <sqm-name-fields slot="formData"></sqm-name-fields>
+              </sqm-portal-register>
+            </template>
 
-              <template path="/emailVerification">
-                <sqm-portal-protected-route
-                  redirect-to="/login"
-                ></sqm-portal-protected-route>
-                <sqm-portal-email-verification></sqm-portal-email-verification>
-              </template>
+            <template path="/emailVerification">
+              <sqm-portal-protected-route
+                redirect-to="/login"
+              ></sqm-portal-protected-route>
+              <sqm-portal-email-verification></sqm-portal-email-verification>
+            </template>
 
-              <template path="/login">
-                <sqm-portal-login></sqm-portal-login>
-              </template>
+            <template path="/login">
+              <sqm-portal-login></sqm-portal-login>
+            </template>
 
-              <template path="/verifyEmail">
-                <sqm-portal-verify-email></sqm-portal-verify-email>
-              </template>
+            <template path="/verifyEmail">
+              <sqm-portal-verify-email></sqm-portal-verify-email>
+            </template>
 
-              <template path="/forgotPassword">
-                <sqm-portal-forgot-password
-                  email-label="Business Email"
-                ></sqm-portal-forgot-password>
-              </template>
+            <template path="/forgotPassword">
+              <sqm-portal-forgot-password
+                email-label="Business Email"
+              ></sqm-portal-forgot-password>
+            </template>
 
-              <template path="/resetPassword">
-                <sqm-portal-reset-password
-                  confirm-password="true"
-                ></sqm-portal-reset-password>
-              </template>
-              <template path="/logout">
-                <sqm-portal-logout next-page="/login"></sqm-portal-logout>
-              </template>
-            </sqm-router>
-          </sqm-hero>
-        </sqm-graphql-client-provider>
+            <template path="/resetPassword">
+              <sqm-portal-reset-password
+                confirm-password="true"
+              ></sqm-portal-reset-password>
+            </template>
+            <template path="/logout">
+              <sqm-portal-logout next-page="/login"></sqm-portal-logout>
+            </template>
+          </sqm-router>
+        </sqm-hero>
       </template>
     </sqm-router>
     <sqm-router>
@@ -130,11 +126,7 @@
                 <sqm-portal-container direction="column" gap="xxx-large">
                   <sqm-portal-profile></sqm-portal-profile></sqm-portal-container
                 ><sqm-portal-container direction="column" gap="xxx-large">
-                  <sqm-graphql-client-provider
-                    domain="https://managed-identity.saasquatch.com"
-                  >
-                    <sqm-portal-change-password></sqm-portal-change-password>
-                  </sqm-graphql-client-provider>
+                  <sqm-portal-change-password></sqm-portal-change-password>
                 </sqm-portal-container>
               </template>
               <template path="/activity">

--- a/packages/mint-components/src/templates/MultiProgramPortalWithDashboard.html
+++ b/packages/mint-components/src/templates/MultiProgramPortalWithDashboard.html
@@ -8,51 +8,47 @@
     </sqm-text>
   </a>
   <sqb-program-section program-id="referral-program-1">
-    <sqm-graphql-client-provider
-      domain="https://managed-identity.saasquatch.com"
+    <sqm-hero
+      background="https://images.unsplash.com/photo-1599676821464-3555954838dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1939&q=80"
     >
-      <sqm-hero
-        background="https://images.unsplash.com/photo-1599676821464-3555954838dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1939&q=80"
-      >
-        <sqm-router>
-          <template path="/register">
-            <sqm-portal-register>
-              <sqm-name-fields slot="formData"></sqm-name-fields>
-            </sqm-portal-register>
-          </template>
+      <sqm-router>
+        <template path="/register">
+          <sqm-portal-register>
+            <sqm-name-fields slot="formData"></sqm-name-fields>
+          </sqm-portal-register>
+        </template>
 
-          <template path="/emailVerification">
-            <sqm-portal-protected-route
-              redirect-to="/login"
-            ></sqm-portal-protected-route>
-            <sqm-portal-email-verification></sqm-portal-email-verification>
-          </template>
+        <template path="/emailVerification">
+          <sqm-portal-protected-route
+            redirect-to="/login"
+          ></sqm-portal-protected-route>
+          <sqm-portal-email-verification></sqm-portal-email-verification>
+        </template>
 
-          <template path="/login">
-            <sqm-portal-login></sqm-portal-login>
-          </template>
+        <template path="/login">
+          <sqm-portal-login></sqm-portal-login>
+        </template>
 
-          <template path="/verifyEmail">
-            <sqm-portal-verify-email></sqm-portal-verify-email>
-          </template>
+        <template path="/verifyEmail">
+          <sqm-portal-verify-email></sqm-portal-verify-email>
+        </template>
 
-          <template path="/forgotPassword">
-            <sqm-portal-forgot-password
-              email-label="Business Email"
-            ></sqm-portal-forgot-password>
-          </template>
+        <template path="/forgotPassword">
+          <sqm-portal-forgot-password
+            email-label="Business Email"
+          ></sqm-portal-forgot-password>
+        </template>
 
-          <template path="/resetPassword">
-            <sqm-portal-reset-password
-              confirm-password="true"
-            ></sqm-portal-reset-password>
-          </template>
-          <template path="/logout">
-            <sqm-portal-logout next-page="/login"></sqm-portal-logout>
-          </template>
-        </sqm-router>
-      </sqm-hero>
-    </sqm-graphql-client-provider>
+        <template path="/resetPassword">
+          <sqm-portal-reset-password
+            confirm-password="true"
+          ></sqm-portal-reset-password>
+        </template>
+        <template path="/logout">
+          <sqm-portal-logout next-page="/login"></sqm-portal-logout>
+        </template>
+      </sqm-router>
+    </sqm-hero>
     <sqm-router>
       <template path="/:path(\bactivity\b|\beditProfile\b)?">
         <sqm-divided-layout
@@ -198,11 +194,7 @@
                 <sqm-portal-container direction="column" gap="xxx-large">
                   <sqm-portal-profile></sqm-portal-profile> </sqm-portal-container
                 ><sqm-portal-container direction="column" gap="xxx-large">
-                  <sqm-graphql-client-provider
-                    domain="https://managed-identity.saasquatch.com"
-                  >
-                    <sqm-portal-change-password></sqm-portal-change-password>
-                  </sqm-graphql-client-provider>
+                  <sqm-portal-change-password></sqm-portal-change-password>
                 </sqm-portal-container>
               </template>
               <template path="/activity">

--- a/packages/mint-components/src/templates/Portal.html
+++ b/packages/mint-components/src/templates/Portal.html
@@ -12,51 +12,47 @@
       <template
         path="/:path(\bregister\b|\bemailVerification\b|\blogin\b|\bverifyEmail\b|\bforgotPassword\b|\bresetPassword\b|\blogout\b)"
       >
-        <sqm-graphql-client-provider
-          domain="https://managed-identity.saasquatch.com"
+        <sqm-hero
+          background="https://images.unsplash.com/photo-1599676821464-3555954838dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1939&q=80"
         >
-          <sqm-hero
-            background="https://images.unsplash.com/photo-1599676821464-3555954838dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1939&q=80"
-          >
-            <sqm-router>
-              <template path="/register">
-                <sqm-portal-register>
-                  <sqm-name-fields slot="formData"></sqm-name-fields>
-                </sqm-portal-register>
-              </template>
+          <sqm-router>
+            <template path="/register">
+              <sqm-portal-register>
+                <sqm-name-fields slot="formData"></sqm-name-fields>
+              </sqm-portal-register>
+            </template>
 
-              <template path="/emailVerification">
-                <sqm-portal-protected-route
-                  redirect-to="/login"
-                ></sqm-portal-protected-route>
-                <sqm-portal-email-verification></sqm-portal-email-verification>
-              </template>
+            <template path="/emailVerification">
+              <sqm-portal-protected-route
+                redirect-to="/login"
+              ></sqm-portal-protected-route>
+              <sqm-portal-email-verification></sqm-portal-email-verification>
+            </template>
 
-              <template path="/login">
-                <sqm-portal-login></sqm-portal-login>
-              </template>
+            <template path="/login">
+              <sqm-portal-login></sqm-portal-login>
+            </template>
 
-              <template path="/verifyEmail">
-                <sqm-portal-verify-email></sqm-portal-verify-email>
-              </template>
+            <template path="/verifyEmail">
+              <sqm-portal-verify-email></sqm-portal-verify-email>
+            </template>
 
-              <template path="/forgotPassword">
-                <sqm-portal-forgot-password
-                  email-label="Business Email"
-                ></sqm-portal-forgot-password>
-              </template>
+            <template path="/forgotPassword">
+              <sqm-portal-forgot-password
+                email-label="Business Email"
+              ></sqm-portal-forgot-password>
+            </template>
 
-              <template path="/resetPassword">
-                <sqm-portal-reset-password
-                  confirm-password="true"
-                ></sqm-portal-reset-password>
-              </template>
-              <template path="/logout">
-                <sqm-portal-logout next-page="/login"></sqm-portal-logout>
-              </template>
-            </sqm-router>
-          </sqm-hero>
-        </sqm-graphql-client-provider>
+            <template path="/resetPassword">
+              <sqm-portal-reset-password
+                confirm-password="true"
+              ></sqm-portal-reset-password>
+            </template>
+            <template path="/logout">
+              <sqm-portal-logout next-page="/login"></sqm-portal-logout>
+            </template>
+          </sqm-router>
+        </sqm-hero>
       </template>
     </sqm-router>
     <sqm-router>
@@ -112,11 +108,7 @@
                 <sqm-portal-container direction="column" gap="xxx-large">
                   <sqm-portal-profile></sqm-portal-profile> </sqm-portal-container
                 ><sqm-portal-container direction="column" gap="xxx-large">
-                  <sqm-graphql-client-provider
-                    domain="https://managed-identity.saasquatch.com"
-                  >
-                    <sqm-portal-change-password></sqm-portal-change-password>
-                  </sqm-graphql-client-provider>
+                  <sqm-portal-change-password></sqm-portal-change-password>
                 </sqm-portal-container>
               </template>
 

--- a/packages/mint-components/src/templates/PortalLeadSubmit.html
+++ b/packages/mint-components/src/templates/PortalLeadSubmit.html
@@ -12,51 +12,47 @@
       <template
         path="/:path(\bregister\b|\bemailVerification\b|\blogin\b|\bverifyEmail\b|\bforgotPassword\b|\bresetPassword\b|\blogout\b)"
       >
-        <sqm-graphql-client-provider
-          domain="https://managed-identity.saasquatch.com"
+        <sqm-hero
+          background="https://images.unsplash.com/photo-1599676821464-3555954838dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1939&q=80"
         >
-          <sqm-hero
-            background="https://images.unsplash.com/photo-1599676821464-3555954838dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1939&q=80"
-          >
-            <sqm-router>
-              <template path="/register">
-                <sqm-portal-register>
-                  <sqm-name-fields slot="formData"></sqm-name-fields>
-                </sqm-portal-register>
-              </template>
+          <sqm-router>
+            <template path="/register">
+              <sqm-portal-register>
+                <sqm-name-fields slot="formData"></sqm-name-fields>
+              </sqm-portal-register>
+            </template>
 
-              <template path="/emailVerification">
-                <sqm-portal-protected-route
-                  redirect-to="/login"
-                ></sqm-portal-protected-route>
-                <sqm-portal-email-verification></sqm-portal-email-verification>
-              </template>
+            <template path="/emailVerification">
+              <sqm-portal-protected-route
+                redirect-to="/login"
+              ></sqm-portal-protected-route>
+              <sqm-portal-email-verification></sqm-portal-email-verification>
+            </template>
 
-              <template path="/login">
-                <sqm-portal-login></sqm-portal-login>
-              </template>
+            <template path="/login">
+              <sqm-portal-login></sqm-portal-login>
+            </template>
 
-              <template path="/verifyEmail">
-                <sqm-portal-verify-email></sqm-portal-verify-email>
-              </template>
+            <template path="/verifyEmail">
+              <sqm-portal-verify-email></sqm-portal-verify-email>
+            </template>
 
-              <template path="/forgotPassword">
-                <sqm-portal-forgot-password
-                  email-label="Business Email"
-                ></sqm-portal-forgot-password>
-              </template>
+            <template path="/forgotPassword">
+              <sqm-portal-forgot-password
+                email-label="Business Email"
+              ></sqm-portal-forgot-password>
+            </template>
 
-              <template path="/resetPassword">
-                <sqm-portal-reset-password
-                  confirm-password="true"
-                ></sqm-portal-reset-password>
-              </template>
-              <template path="/logout">
-                <sqm-portal-logout next-page="/login"></sqm-portal-logout>
-              </template>
-            </sqm-router>
-          </sqm-hero>
-        </sqm-graphql-client-provider>
+            <template path="/resetPassword">
+              <sqm-portal-reset-password
+                confirm-password="true"
+              ></sqm-portal-reset-password>
+            </template>
+            <template path="/logout">
+              <sqm-portal-logout next-page="/login"></sqm-portal-logout>
+            </template>
+          </sqm-router>
+        </sqm-hero>
       </template>
     </sqm-router>
     <sqm-router>
@@ -117,11 +113,7 @@
                 <sqm-portal-container direction="column" gap="xxx-large">
                   <sqm-portal-profile></sqm-portal-profile> </sqm-portal-container
                 ><sqm-portal-container direction="column" gap="xxx-large">
-                  <sqm-graphql-client-provider
-                    domain="https://managed-identity.saasquatch.com"
-                  >
-                    <sqm-portal-change-password></sqm-portal-change-password>
-                  </sqm-graphql-client-provider>
+                  <sqm-portal-change-password></sqm-portal-change-password>
                 </sqm-portal-container>
               </template>
               <template path="/refer">

--- a/packages/mint-components/src/templates/PortalLeadSubmitWithDashboard.html
+++ b/packages/mint-components/src/templates/PortalLeadSubmitWithDashboard.html
@@ -12,51 +12,47 @@
       <template
         path="/:path(\bregister\b|\bemailVerification\b|\blogin\b|\bverifyEmail\b|\bforgotPassword\b|\bresetPassword\b|\blogout\b)"
       >
-        <sqm-graphql-client-provider
-          domain="https://managed-identity.saasquatch.com"
+        <sqm-hero
+          background="https://images.unsplash.com/photo-1599676821464-3555954838dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1939&q=80"
         >
-          <sqm-hero
-            background="https://images.unsplash.com/photo-1599676821464-3555954838dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1939&q=80"
-          >
-            <sqm-router>
-              <template path="/register">
-                <sqm-portal-register>
-                  <sqm-name-fields slot="formData"></sqm-name-fields>
-                </sqm-portal-register>
-              </template>
+          <sqm-router>
+            <template path="/register">
+              <sqm-portal-register>
+                <sqm-name-fields slot="formData"></sqm-name-fields>
+              </sqm-portal-register>
+            </template>
 
-              <template path="/emailVerification">
-                <sqm-portal-protected-route
-                  redirect-to="/login"
-                ></sqm-portal-protected-route>
-                <sqm-portal-email-verification></sqm-portal-email-verification>
-              </template>
+            <template path="/emailVerification">
+              <sqm-portal-protected-route
+                redirect-to="/login"
+              ></sqm-portal-protected-route>
+              <sqm-portal-email-verification></sqm-portal-email-verification>
+            </template>
 
-              <template path="/login">
-                <sqm-portal-login></sqm-portal-login>
-              </template>
+            <template path="/login">
+              <sqm-portal-login></sqm-portal-login>
+            </template>
 
-              <template path="/verifyEmail">
-                <sqm-portal-verify-email></sqm-portal-verify-email>
-              </template>
+            <template path="/verifyEmail">
+              <sqm-portal-verify-email></sqm-portal-verify-email>
+            </template>
 
-              <template path="/forgotPassword">
-                <sqm-portal-forgot-password
-                  email-label="Business Email"
-                ></sqm-portal-forgot-password>
-              </template>
+            <template path="/forgotPassword">
+              <sqm-portal-forgot-password
+                email-label="Business Email"
+              ></sqm-portal-forgot-password>
+            </template>
 
-              <template path="/resetPassword">
-                <sqm-portal-reset-password
-                  confirm-password="true"
-                ></sqm-portal-reset-password>
-              </template>
-              <template path="/logout">
-                <sqm-portal-logout next-page="/login"></sqm-portal-logout>
-              </template>
-            </sqm-router>
-          </sqm-hero>
-        </sqm-graphql-client-provider>
+            <template path="/resetPassword">
+              <sqm-portal-reset-password
+                confirm-password="true"
+              ></sqm-portal-reset-password>
+            </template>
+            <template path="/logout">
+              <sqm-portal-logout next-page="/login"></sqm-portal-logout>
+            </template>
+          </sqm-router>
+        </sqm-hero>
       </template>
     </sqm-router>
     <sqm-router>
@@ -201,11 +197,7 @@
                 <sqm-portal-container direction="column" gap="xxx-large">
                   <sqm-portal-profile></sqm-portal-profile> </sqm-portal-container
                 ><sqm-portal-container direction="column" gap="xxx-large">
-                  <sqm-graphql-client-provider
-                    domain="https://managed-identity.saasquatch.com"
-                  >
-                    <sqm-portal-change-password></sqm-portal-change-password>
-                  </sqm-graphql-client-provider>
+                  <sqm-portal-change-password></sqm-portal-change-password>
                 </sqm-portal-container>
               </template>
               <template path="/refer">

--- a/packages/mint-components/src/templates/PortalWithDashboard.html
+++ b/packages/mint-components/src/templates/PortalWithDashboard.html
@@ -12,51 +12,47 @@
       <template
         path="/:path(\bregister\b|\bemailVerification\b|\blogin\b|\bverifyEmail\b|\bforgotPassword\b|\bresetPassword\b|\blogout\b)"
       >
-        <sqm-graphql-client-provider
-          domain="https://managed-identity.saasquatch.com"
+        <sqm-hero
+          background="https://images.unsplash.com/photo-1599676821464-3555954838dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1939&q=80"
         >
-          <sqm-hero
-            background="https://images.unsplash.com/photo-1599676821464-3555954838dc?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1939&q=80"
-          >
-            <sqm-router>
-              <template path="/register">
-                <sqm-portal-register>
-                  <sqm-name-fields slot="formData"></sqm-name-fields>
-                </sqm-portal-register>
-              </template>
+          <sqm-router>
+            <template path="/register">
+              <sqm-portal-register>
+                <sqm-name-fields slot="formData"></sqm-name-fields>
+              </sqm-portal-register>
+            </template>
 
-              <template path="/emailVerification">
-                <sqm-portal-protected-route
-                  redirect-to="/login"
-                ></sqm-portal-protected-route>
-                <sqm-portal-email-verification></sqm-portal-email-verification>
-              </template>
+            <template path="/emailVerification">
+              <sqm-portal-protected-route
+                redirect-to="/login"
+              ></sqm-portal-protected-route>
+              <sqm-portal-email-verification></sqm-portal-email-verification>
+            </template>
 
-              <template path="/login">
-                <sqm-portal-login></sqm-portal-login>
-              </template>
+            <template path="/login">
+              <sqm-portal-login></sqm-portal-login>
+            </template>
 
-              <template path="/verifyEmail">
-                <sqm-portal-verify-email></sqm-portal-verify-email>
-              </template>
+            <template path="/verifyEmail">
+              <sqm-portal-verify-email></sqm-portal-verify-email>
+            </template>
 
-              <template path="/forgotPassword">
-                <sqm-portal-forgot-password
-                  email-label="Business Email"
-                ></sqm-portal-forgot-password>
-              </template>
+            <template path="/forgotPassword">
+              <sqm-portal-forgot-password
+                email-label="Business Email"
+              ></sqm-portal-forgot-password>
+            </template>
 
-              <template path="/resetPassword">
-                <sqm-portal-reset-password
-                  confirm-password="true"
-                ></sqm-portal-reset-password>
-              </template>
-              <template path="/logout">
-                <sqm-portal-logout next-page="/login"></sqm-portal-logout>
-              </template>
-            </sqm-router>
-          </sqm-hero>
-        </sqm-graphql-client-provider>
+            <template path="/resetPassword">
+              <sqm-portal-reset-password
+                confirm-password="true"
+              ></sqm-portal-reset-password>
+            </template>
+            <template path="/logout">
+              <sqm-portal-logout next-page="/login"></sqm-portal-logout>
+            </template>
+          </sqm-router>
+        </sqm-hero>
       </template>
     </sqm-router>
     <sqm-router>
@@ -189,11 +185,7 @@
                 <sqm-portal-container direction="column" gap="xxx-large">
                   <sqm-portal-profile></sqm-portal-profile> </sqm-portal-container
                 ><sqm-portal-container direction="column" gap="xxx-large">
-                  <sqm-graphql-client-provider
-                    domain="https://managed-identity.saasquatch.com"
-                  >
-                    <sqm-portal-change-password></sqm-portal-change-password>
-                  </sqm-graphql-client-provider>
+                  <sqm-portal-change-password></sqm-portal-change-password>
                 </sqm-portal-container>
               </template>
 


### PR DESCRIPTION
## Description of the change

Remove sqm-graphql-client-provider from portal templates as it no longer is needed and points to old managed identity.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

- Jira issue number: DEV-3245
- Process.st launch checklist: [here](https://app.process.st/runs/DEV-3245-Managed-Identity-Update-P1-pSOkYd7fnJIXgPkZ2KpO5g/tasks/qBvpKTmwIaUys0BnmCFFIA)

## Checklists

### Development

- [ ] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)
- [ ] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist

### Code review

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
