### PR TITLE
[DEV-3304] component-environment: Improved browser locale handling

### DIFF
--- a/packages/component-environment/CHANGELOG.md
+++ b/packages/component-environment/CHANGELOG.md
@@ -5,9 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2022-09-13
+
+### Changed
+
+- Validate the browser's navigator.language is a simple locale with no extension to be compatible
+  with the backend
+
 ## [1.0.0] - 2022-07-21
 
 Initial version.
 
-[unreleased]: https://github.com/saasquatch/program-tools/compare/%40saasquatch%2Fcomponent-environment%401.0.0...HEAD
+[unreleased]: https://github.com/saasquatch/program-tools/compare/%40saasquatch%2Fcomponent-environment%401.0.1...HEAD
+[1.0.1]: https://github.com/saasquatch/program-tools/releases/tag/%40saasquatch%2Fcomponent-environment%401.0.1
 [1.0.0]: https://github.com/saasquatch/program-tools/releases/tag/%40saasquatch%2Fcomponent-environment%401.0.0

--- a/packages/component-environment/__tests__/features/Locale.feature
+++ b/packages/component-environment/__tests__/features/Locale.feature
@@ -1,0 +1,34 @@
+Feature: Locale handling
+
+    Scenario: Initial locale is obtained from the browser
+        Given the locale context is started
+        When the initial value is set
+        And there is no widgetIdent locale
+        Then the initial value for the context will be the parsed navigator.language
+
+    Scenario: navigator.language is converted to a locale the backend understands
+        Given the locale context is started
+        And the value of navigator.language is used as the initial value
+        When the initial context value is set
+        Then is the value of navigator.language with dashes replaced with underscores
+
+    Scenario Outline: Browser locale is validated to work with the backend
+        Given the browser's navigator.language is <language>
+        When the locale is validated
+        Then the value <will> be used
+
+        Examples:
+            | language        | will  |
+            | en-US           | will  |
+            | sr-Latn-SR      | won't |
+            | es-419          | will  |
+            | en-029          | will  |
+            | de-DE-1901-1901 | won't |
+            | az-Arab-IR      | won't |
+            | en-GB-oxendict  | won't |
+
+    Scenario: Locale is undefined if there is no valid initial value
+        Given the locale context is started
+        And the browser's locale is not valid
+        And there is no widgetIdent locale
+        Then the initial value will be undefined

--- a/packages/component-environment/__tests__/features/Locale.feature
+++ b/packages/component-environment/__tests__/features/Locale.feature
@@ -31,4 +31,4 @@ Feature: Locale handling
         Given the locale context is started
         And the browser's locale is not valid
         And there is no widgetIdent locale
-        Then the initial value will be undefined
+        Then the initial value is undefined

--- a/packages/component-environment/__tests__/features/Locale.feature
+++ b/packages/component-environment/__tests__/features/Locale.feature
@@ -4,7 +4,7 @@ Feature: Locale handling
         Given the locale context is started
         When the initial value is set
         And there is no widgetIdent locale
-        Then the initial value for the context will be the parsed navigator.language
+        Then the initial value for the context is the parsed navigator.language
 
     Scenario: navigator.language is converted to a locale the backend understands
         Given the locale context is started

--- a/packages/component-environment/__tests__/features/Locale.feature
+++ b/packages/component-environment/__tests__/features/Locale.feature
@@ -1,17 +1,22 @@
+@author:johan
+@owner:johan
 Feature: Locale handling
 
+    @motivating
     Scenario: Initial locale is obtained from the browser
         Given the locale context is started
         When the initial value is set
         And there is no widgetIdent locale
         Then the initial value for the context is the parsed navigator.language
 
+    @motivating
     Scenario: navigator.language is converted to a locale the backend understands
         Given the locale context is started
         And the value of navigator.language is used as the initial value
         When the initial context value is set
         Then is the value of navigator.language with dashes replaced with underscores
 
+    @motivating
     Scenario Outline: Browser locale is validated to work with the backend
         Given the browser's navigator.language is <language>
         When the locale is validated
@@ -27,6 +32,7 @@ Feature: Locale handling
             | az-Arab-IR      | won't |
             | en-GB-oxendict  | won't |
 
+    @minutia
     Scenario: Locale is undefined if there is no valid initial value
         Given the locale context is started
         And the browser's locale is not valid

--- a/packages/component-environment/__tests__/validateLocale.spec.ts
+++ b/packages/component-environment/__tests__/validateLocale.spec.ts
@@ -1,0 +1,29 @@
+import { validateLocale } from "../src/contexts/LocaleContext";
+
+describe("Validate locale", () => {
+  it("returns undefined when locale is undefined", () => {
+    expect(validateLocale(undefined)).toBeUndefined();
+  });
+
+  it("expects the locale to be in the format xx_XX", () => {
+    const testCases = {
+      xx_XX: true,
+      xx_xx: false,
+      en_us: false,
+      EN_US: false,
+      en_US: true,
+      hello: false,
+      sr_Latn_sr: false,
+      es_419: true,
+      de_DE_1901_1901: false,
+      az_Arab_IR: false,
+      en_029: true,
+      "en_GB-oxendict": false,
+    };
+
+    Object.entries(testCases).forEach(([key, shouldPass]) => {
+      const result = validateLocale(key);
+      shouldPass ? expect(result).toEqual(key) : expect(result).toBeUndefined();
+    });
+  });
+});

--- a/packages/component-environment/package-lock.json
+++ b/packages/component-environment/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saasquatch/component-environment",
-  "version": "1.0.1-2",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saasquatch/component-environment",
-      "version": "1.0.1-2",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@wry/equality": "^0.5.2",

--- a/packages/component-environment/package-lock.json
+++ b/packages/component-environment/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saasquatch/component-environment",
-  "version": "1.0.0",
+  "version": "1.0.1-2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saasquatch/component-environment",
-      "version": "1.0.0",
+      "version": "1.0.1-2",
       "license": "ISC",
       "dependencies": {
         "@wry/equality": "^0.5.2",

--- a/packages/component-environment/package.json
+++ b/packages/component-environment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/component-environment",
-  "version": "1.0.1-2",
+  "version": "1.0.1",
   "description": "Environment and contexts for SaaSquatch components",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/component-environment/package.json
+++ b/packages/component-environment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/component-environment",
-  "version": "1.0.0",
+  "version": "1.0.1-2",
   "description": "Environment and contexts for SaaSquatch components",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/component-environment/src/contexts/LocaleContext.ts
+++ b/packages/component-environment/src/contexts/LocaleContext.ts
@@ -16,10 +16,17 @@ export function lazilyStartLocaleContext() {
   if (!globalProvider) {
     debug("Creating locale context provider");
 
+    let locale = window.widgetIdent?.locale;
+    if (!locale) {
+      const browserLocale = navigator.language.replace("-", "_");
+      if (/[a-z]{2}_[A-Z]{2}/.test(browserLocale)) {
+        locale = browserLocale;
+      }
+    }
+
     globalProvider = new ContextProvider<string | undefined>({
       element: document.documentElement,
-      initialState:
-        window.widgetIdent?.locale || navigator.language.replace("-", "_"),
+      initialState: locale,
       contextName: LOCALE_CONTEXT_NAME,
     }).start();
 

--- a/packages/component-environment/src/contexts/LocaleContext.ts
+++ b/packages/component-environment/src/contexts/LocaleContext.ts
@@ -4,6 +4,12 @@ import { debug as _debug } from "../debug";
 
 const debug = (...args: any[]) => _debug(LOCALE_CONTEXT_NAME, ...args);
 
+export function validateLocale(locale?: string) {
+  if (locale && /^[a-z]{2}_(?:[A-Z]{2}|[0-9]{3})$/.test(locale)) {
+    return locale;
+  }
+}
+
 /**
  * Lazily start the locale context provider. If it already exists, the existing provider is
  * returned. This function is safe to call multiple times.
@@ -16,13 +22,9 @@ export function lazilyStartLocaleContext() {
   if (!globalProvider) {
     debug("Creating locale context provider");
 
-    let locale = window.widgetIdent?.locale;
-    if (!locale) {
-      const browserLocale = navigator.language.replace("-", "_");
-      if (/[a-z]{2}_[A-Z]{2}/.test(browserLocale)) {
-        locale = browserLocale;
-      }
-    }
+    const locale =
+      window.widgetIdent?.locale ??
+      validateLocale(navigator.language.replaceAll("-", "_"));
 
     globalProvider = new ContextProvider<string | undefined>({
       element: document.documentElement,

--- a/packages/component-environment/src/listeners.ts
+++ b/packages/component-environment/src/listeners.ts
@@ -1,7 +1,10 @@
 import { ContextListener } from "dom-context";
 import { USER_CONTEXT_NAME, LOCALE_CONTEXT_NAME } from "./types";
 import { UserIdentity } from "./types";
-import { lazilyStartLocaleContext } from "./contexts/LocaleContext";
+import {
+  lazilyStartLocaleContext,
+  validateLocale,
+} from "./contexts/LocaleContext";
 import { fetchLocale } from "./fetchLocale";
 import { debug as _debug } from "./debug";
 
@@ -27,7 +30,8 @@ const userContextListenerForLocale = new ContextListener<
   onChange: async (next) => {
     const localeProvider = lazilyStartLocaleContext();
     const defaultLocale =
-      window.widgetIdent?.locale || navigator.language.replace("-", "_");
+      window.widgetIdent?.locale ??
+      validateLocale(navigator.language.replaceAll("-", "_"));
 
     let newLocale;
     if (next) {


### PR DESCRIPTION
## Description of the change

Some locales have extensions, like `sr-Latn-SR` or `en-GB-oxendict`, which are mangled by the Java Locale object. This causes invalid locales to be used for microsite page rendering, and results in an error.

This change validates that the browser's `navigator.language` matches a basic locale regular expression (based on the documentation at https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html) before trying to use it as a default.

The net effect is `navigator.language` will only be used as a default locale in the cases where we know we can use it in `renderMicrositePage`, otherwise it's ignored. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

- Jira issue number: [Checklist](https://app.process.st/runs/DEV-3304-component-environment-Improved-browser-locale-handling-h-HnXlSeLSLjF5CfAD9MNg/tasks/ipJPSwLUytFe3xMt6P5PYw)
- Process.st launch checklist: [DEV-3304](https://saasquatch.atlassian.net/browse/DEV-3304)

## Checklists

### Development

- [x] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)
- [ ] The behaviour changes in the pull request are covered by specs
- [x] All tests related to the changed code pass in development

### Paperwork

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has a Jira number
- [x] This pull request has a Process.st launch checklist

### Code review

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
