### PR TITLE
Patch fix for icon view

### DIFF
--- a/packages/visual-dev/CHANGELOG.md
+++ b/packages/visual-dev/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2022-09-22
+
+### Changed
+
+- Components changed
+  - \<Icon>
+    - removed center alignment from default icon styling, and added prop to overwrite existing styles and center the icon
+
 ## [1.1.0] - 2022-09-21
 
 ### Added
@@ -165,7 +173,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - \<TextArea>
   - \<Tooltip>
 
-[unreleased]: https://github.com/saasquatch/program-tools/compare/visual-dev%401.1.0...HEAD
+[unreleased]: https://github.com/saasquatch/program-tools/compare/visual-dev%401.1.1...HEAD
+[1.1.1]: https://github.com/saasquatch/program-tools/releases/tag/%40saasquatch/visual-dev%401.1.1
 [1.1.0]: https://github.com/saasquatch/program-tools/releases/tag/%40saasquatch/visual-dev%401.1.0
 [1.0.2]: https://github.com/saasquatch/program-tools/releases/tag/%40saasquatch/visual-dev%401.0.2
 [1.0.1]: https://github.com/saasquatch/program-tools/releases/tag/%40saasquatch/visual-dev%401.0.1

--- a/packages/visual-dev/package.json
+++ b/packages/visual-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/visual-dev",
-  "version": "1.1.1-2",
+  "version": "1.1.1",
   "description": "SaaSquatch visual dev",
   "main": "dist/index.js",
   "module": "dist/visual-dev.esm.js",

--- a/packages/visual-dev/package.json
+++ b/packages/visual-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/visual-dev",
-  "version": "1.1.0",
+  "version": "1.1.1-2",
   "description": "SaaSquatch visual dev",
   "main": "dist/index.js",
   "module": "dist/visual-dev.esm.js",

--- a/packages/visual-dev/src/components/Icon/Icon.tsx
+++ b/packages/visual-dev/src/components/Icon/Icon.tsx
@@ -30,6 +30,10 @@ export interface StyleProps {
    */
   cursor?: string;
   /**
+   * Align icon to center
+   */
+  center?: boolean;
+  /**
    * Custom CSS styles applied to icon
    */
   customCSS?: CSSProp;
@@ -44,9 +48,7 @@ const default_size = {
 
 const SVGStyleSpan = styled.span<Required<StyleProps>>`
   ${Styles.base}
-  display: flex;
-  align-items: center;
-  justify-content: center;
+
   color: ${(props) => props.color};
   width: ${(props) =>
     default_size.hasOwnProperty(props.size)
@@ -57,6 +59,14 @@ const SVGStyleSpan = styled.span<Required<StyleProps>>`
       ? default_size[props.size as Size]
       : props.size};
   ${(props) => props.customCSS}
+
+  ${(props) =>
+    props.center
+      ? `display: flex !important;
+         align-items: center;
+         justify-content: center;
+         `
+      : ""}
 
   & > svg {
     cursor: ${(props) => (props.cursor ? props.cursor : "default")};
@@ -76,6 +86,7 @@ export const IconView = React.forwardRef<React.ElementRef<"div">, IconProps>(
       color = "inherit",
       size = "medium",
       cursor = "default",
+      center = false,
       customCSS = {},
       ...rest
     } = props;
@@ -88,6 +99,7 @@ export const IconView = React.forwardRef<React.ElementRef<"div">, IconProps>(
         ref={forwardedRef}
         customCSS={customCSS}
         cursor={cursor}
+        center={center}
       >
         {Object.keys(SVGs).includes(icon) ? SVGs[icon] : SVGs["placeholder"]}
       </SVGStyleSpan>


### PR DESCRIPTION
## Description of the change

> Fixed regression for by removing styling to center align all icons which was causing the IconButonView to break. Instead a prop was added to overwrite existing alignment styles when needed.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

- Storybook: https://visual-dev.stencilbook.saasquat.ch/pr303/index.html

### Development

- [X] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)
- [ ] The behaviour changes in the pull request are covered by specs
- [X] All tests related to the changed code pass in development

### Paperwork

- [X] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist

### Code review

- [ ] Changes have been reviewed by at least one other engineer
- [X] Security impacts of this change have been considered
