### PR TITLE
[DEV-3372] Support `request_id` attribute in http middleware

### DIFF
--- a/packages/logger/package-lock.json
+++ b/packages/logger/package-lock.json
@@ -12,7 +12,7 @@
         "@types/node": "16"
       },
       "engines": {
-        "node": ">=16"
+        "node": "^16 || ^18"
       },
       "peerDependencies": {
         "express": "4",

--- a/packages/logger/package-lock.json
+++ b/packages/logger/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saasquatch/logger",
-  "version": "1.1.0-0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saasquatch/logger",
-      "version": "1.1.0-0",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "16"

--- a/packages/logger/package-lock.json
+++ b/packages/logger/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saasquatch/logger",
-  "version": "1.0.0",
+  "version": "1.1.0-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saasquatch/logger",
-      "version": "1.0.0",
+      "version": "1.1.0-0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "16"

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/logger",
-  "version": "1.1.0-0",
+  "version": "1.1.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/logger",
-  "version": "1.0.0",
+  "version": "1.1.0-0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/logger/src/format.ts
+++ b/packages/logger/src/format.ts
@@ -74,6 +74,10 @@ const formatHttpLog = winston.format((info) => {
     newInfo["http.method"] = message.method;
     newInfo["http.status_code"] = message.status;
     newInfo["http.response_time"] = message.time;
+
+    if (message.requestId) {
+      newInfo["http.request_id"] = message.requestId;
+    }
   }
 
   return newInfo;


### PR DESCRIPTION
## Description of the change

Adds support for including the `http.request_id` attribute in logs where the request ID has been set in the response context.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

- Jira issue number: [DEV-3372](https://saasquatch.atlassian.net/browse/DEV-3372)
- Process.st launch checklist: (PUT IT HERE)

## Checklists

### Development

- [x] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)
- [ ] The behaviour changes in the pull request are covered by specs
- [x] All tests related to the changed code pass in development

### Paperwork

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist

### Code review

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered


[DEV-3372]: https://saasquatch.atlassian.net/browse/DEV-3372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ