### PR TITLE
M2: Add referralId to email transactions for GA fraud moderation

### DIFF
--- a/packages/program-boilerplate/CHANGELOG.md
+++ b/packages/program-boilerplate/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.7.3] - 2023-12-14
+
+### Changed
+
+- Added referralId to email mutations when rewardId is not present; this will attach the email to the referral.
+
 ## [3.7.1] - 2023-04-20
 
 ### Changed
+
 - Updated license copyright to be in line with SaaSquatch open-source policy.
 
 ## [3.7.0] - 2023-01-17

--- a/packages/program-boilerplate/CHANGELOG.md
+++ b/packages/program-boilerplate/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.7.3] - 2023-12-14
+## [3.7.3] - 2024-01-04
 
 ### Changed
 

--- a/packages/program-boilerplate/__tests__/transaction.test.ts
+++ b/packages/program-boilerplate/__tests__/transaction.test.ts
@@ -242,6 +242,7 @@ describe("Transaction class", () => {
             },
             key: emailKey,
             rewardId: rewardId,
+            referralId: undefined,
             queryVariables: {
               userId: "reffererID",
               accountId: "reffererACCOUNTID",
@@ -271,6 +272,7 @@ describe("Transaction class", () => {
             },
             key: emailKey,
             rewardId: undefined,
+            referralId,
             queryVariables: {
               userId: "reffererID",
               accountId: "reffererACCOUNTID",
@@ -384,6 +386,7 @@ describe("Transaction class", () => {
           },
           key: emailKey,
           rewardId: rewardMutation.data.rewardId,
+          referralId: undefined,
           queryVariables: {
             userId: "reffererID",
             accountId: "reffererACCOUNTID",

--- a/packages/program-boilerplate/package-lock.json
+++ b/packages/program-boilerplate/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.7.3-0",
+  "version": "3.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saasquatch/program-boilerplate",
-      "version": "3.7.3-0",
+      "version": "3.7.3",
       "license": "MIT",
       "dependencies": {
         "@saasquatch/jsonata-paths-extractor": "^1.0.1",

--- a/packages/program-boilerplate/package-lock.json
+++ b/packages/program-boilerplate/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.7.1",
+  "version": "3.7.3-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saasquatch/program-boilerplate",
-      "version": "3.7.1",
+      "version": "3.7.3-0",
       "license": "MIT",
       "dependencies": {
         "@saasquatch/jsonata-paths-extractor": "^1.0.1",

--- a/packages/program-boilerplate/package.json
+++ b/packages/program-boilerplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.7.3-0",
+  "version": "3.7.3",
   "description": "Boilerplate for writing programs",
   "main": "dist/index.js",
   "files": [

--- a/packages/program-boilerplate/package.json
+++ b/packages/program-boilerplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/program-boilerplate",
-  "version": "3.7.1",
+  "version": "3.7.3-0",
   "description": "Boilerplate for writing programs",
   "main": "dist/index.js",
   "files": [

--- a/packages/program-boilerplate/src/transaction.ts
+++ b/packages/program-boilerplate/src/transaction.ts
@@ -266,6 +266,9 @@ export default class Transaction {
           accountId: user.accountId,
         },
         rewardId,
+        // add the referralId only if the rewardIf is undefined
+        // this will cause a graph edge between the referral and the email for moderation
+        referralId: rewardId ? undefined : referralId,
         key: emailKey,
         queryVariables: queryVariables,
         query: rewardId


### PR DESCRIPTION
## Description of the change

Add referralId to email transactions for GA fraud moderation in program-boilerplate
- only attach the referralId if the rewardId is undefined
- this will create a graph edge between the referral and the email

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

- Jira issue number: https://impact.atlassian.net/browse/SQDEV-3523
- Process.st launch checklist: https://app.process.st/runs/M2-Backend-GA-Fraud-hrZ9paY4QNT3WwRkj1JOrw/tasks/ipJPSwLUytFe3xMt6P5PYw

## Checklists

### Development

- [x] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)
- [ ] The behaviour changes in the pull request are covered by specs
- [x] All tests related to the changed code pass in development

### Paperwork

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has a Jira number
- [x] This pull request has a Process.st launch checklist

### Code review

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
