### PR TITLE
[Bug fix] correctly use engagement medium when querying for share links

### DIFF
--- a/packages/mint-components/CHANGELOG.md
+++ b/packages/mint-components/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.7.0] - 2023-01-08
 
+### Fixed
+
+- Changed components:
+  - \<sqm-share-link>
+    - Correctly uses the current engagementMedium when retrieving the sharelink
+
+## [1.7.0] - 2023-01-08
+
 ### Added
 
 - Added support for fraud referral moderation to multiple components
@@ -798,7 +806,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - \<sqm-popup-container>
   - \<sqm-stencilbook>
 
-[unreleased]: https://github.com/saasquatch/program-tools/compare/mint-components@1.6.18...HEAD
+[unreleased]: https://github.com/saasquatch/program-tools/compare/mint-components@1.7.1...HEAD
+[1.7.1]: https://github.com/saasquatch/program-tools/releases/tag/%40saasquatch%2Fmint-components%401.7.1
+[1.7.0]: https://github.com/saasquatch/program-tools/releases/tag/%40saasquatch%2Fmint-components%401.7.0
 [1.6.18]: https://github.com/saasquatch/program-tools/releases/tag/%40saasquatch%2Fmint-components%401.6.18
 [1.6.17]: https://github.com/saasquatch/program-tools/releases/tag/%40saasquatch%2Fmint-components%401.6.17
 [1.6.16]: https://github.com/saasquatch/program-tools/releases/tag/%40saasquatch%2Fmint-components%401.6.16

--- a/packages/mint-components/package-lock.json
+++ b/packages/mint-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saasquatch/mint-components",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saasquatch/mint-components",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/mint-components/package.json
+++ b/packages/mint-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@saasquatch/mint-components",
   "title": "Mint Components",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A minimal design library with components for referral and loyalty experiences. Built with Shoelace components by Saasquatch.",
   "icon": "https://res.cloudinary.com/saasquatch/image/upload/v1652219900/squatch-assets/For_Mint.svg",
   "raisins": "docs/raisins.json",

--- a/packages/mint-components/src/components/sqm-share-link/useShareLink.tsx
+++ b/packages/mint-components/src/components/sqm-share-link/useShareLink.tsx
@@ -16,10 +16,10 @@ interface ShareLinkProps {
 }
 
 const MessageLinkQuery = gql`
-  query ($programId: ID) {
+  query ($programId: ID, $engagementMedium: UserEngagementMedium!) {
     user: viewer {
       ... on User {
-        shareLink(programId: $programId)
+        shareLink(programId: $programId, engagementMedium: $engagementMedium)
       }
     }
   }
@@ -36,7 +36,11 @@ export function useShareLink(props: ShareLinkProps): CopyTextViewProps {
   const user = useUserIdentity();
   const engagementMedium = useEngagementMedium();
 
-  const { data } = useQuery(MessageLinkQuery, { programId }, !user?.jwt);
+  const { data } = useQuery(
+    MessageLinkQuery,
+    { programId, engagementMedium },
+    !user?.jwt
+  );
   const [sendLoadEvent] = useMutation(WIDGET_ENGAGEMENT_EVENT);
 
   const copyString =


### PR DESCRIPTION
## Description of the change

> Share link was previously always resulting in an engagementMedium of "UNKNOWN" 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

- Jira issue number: (PUT IT HERE)
- Process.st launch checklist: (PUT IT HERE)

## Checklists

### Development

- [ ] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)
- [ ] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist

### Code review

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
