### PR TITLE
Fire event on instant access user registration for squatchjs

### DIFF
--- a/packages/bedrock-components/CHANGELOG.md
+++ b/packages/bedrock-components/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2023-02-06
+
+### Updated
+
+- `@saasquatch/component-boilerplate` package bump
+
 ## [1.4.0] - 2023-01-08
 
 ### Changed

--- a/packages/bedrock-components/package-lock.json
+++ b/packages/bedrock-components/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@saasquatch/bedrock-components",
-  "version": "1.4.1-0",
+  "version": "1.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saasquatch/bedrock-components",
-      "version": "1.4.1-0",
+      "version": "1.4.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@raisins/stencil-docs-target": "^1.0.0",
-        "@saasquatch/component-boilerplate": "^1.6.1-0",
+        "@saasquatch/component-boilerplate": "^1.6.1",
         "@saasquatch/stencil-hooks": "^2.0.2",
         "@saasquatch/stencilbook": "^1.0.0",
         "@saasquatch/universal-hooks": "^1.0.0",
@@ -2657,9 +2657,9 @@
       }
     },
     "node_modules/@saasquatch/component-boilerplate": {
-      "version": "1.6.1-0",
-      "resolved": "https://registry.npmjs.org/@saasquatch/component-boilerplate/-/component-boilerplate-1.6.1-0.tgz",
-      "integrity": "sha512-6CLdT9bW2HH9xx7tlQac6YL7GWcG2BnYwXyVUSe/1lAw6d1gHd/Hw4KrNwICJOCror9Uk8O0lGiJ8enpWhFDBw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@saasquatch/component-boilerplate/-/component-boilerplate-1.6.1.tgz",
+      "integrity": "sha512-jDs1/atMhl1K3RbGQixeluFR85WmoheLdBEs4yAFDgtQaqjljSJbtdz54BUPwkIHEQfs1vzUy63CaxGPXUYJoQ==",
       "dependencies": {
         "@formatjs/intl": "^1.8.2",
         "@saasquatch/component-environment": "^1.0.4",
@@ -14016,9 +14016,9 @@
       }
     },
     "@saasquatch/component-boilerplate": {
-      "version": "1.6.1-0",
-      "resolved": "https://registry.npmjs.org/@saasquatch/component-boilerplate/-/component-boilerplate-1.6.1-0.tgz",
-      "integrity": "sha512-6CLdT9bW2HH9xx7tlQac6YL7GWcG2BnYwXyVUSe/1lAw6d1gHd/Hw4KrNwICJOCror9Uk8O0lGiJ8enpWhFDBw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@saasquatch/component-boilerplate/-/component-boilerplate-1.6.1.tgz",
+      "integrity": "sha512-jDs1/atMhl1K3RbGQixeluFR85WmoheLdBEs4yAFDgtQaqjljSJbtdz54BUPwkIHEQfs1vzUy63CaxGPXUYJoQ==",
       "requires": {
         "@formatjs/intl": "^1.8.2",
         "@saasquatch/component-environment": "^1.0.4",

--- a/packages/bedrock-components/package-lock.json
+++ b/packages/bedrock-components/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@saasquatch/bedrock-components",
-  "version": "1.4.0",
+  "version": "1.4.1-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saasquatch/bedrock-components",
-      "version": "1.4.0",
+      "version": "1.4.1-0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@raisins/stencil-docs-target": "^1.0.0",
-        "@saasquatch/component-boilerplate": "^1.6.0",
+        "@saasquatch/component-boilerplate": "^1.6.1-0",
         "@saasquatch/stencil-hooks": "^2.0.2",
         "@saasquatch/stencilbook": "^1.0.0",
         "@saasquatch/universal-hooks": "^1.0.0",
@@ -2657,9 +2657,9 @@
       }
     },
     "node_modules/@saasquatch/component-boilerplate": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@saasquatch/component-boilerplate/-/component-boilerplate-1.6.0.tgz",
-      "integrity": "sha512-QjTCHU8z/VtihVTHymfNBb6hzcQn/spoRTDt+pCVKPkpBhZ9KzN9dxMvNjFQbbpH5ZFKkvI73lrIilP/OKtrZg==",
+      "version": "1.6.1-0",
+      "resolved": "https://registry.npmjs.org/@saasquatch/component-boilerplate/-/component-boilerplate-1.6.1-0.tgz",
+      "integrity": "sha512-6CLdT9bW2HH9xx7tlQac6YL7GWcG2BnYwXyVUSe/1lAw6d1gHd/Hw4KrNwICJOCror9Uk8O0lGiJ8enpWhFDBw==",
       "dependencies": {
         "@formatjs/intl": "^1.8.2",
         "@saasquatch/component-environment": "^1.0.4",
@@ -14016,9 +14016,9 @@
       }
     },
     "@saasquatch/component-boilerplate": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@saasquatch/component-boilerplate/-/component-boilerplate-1.6.0.tgz",
-      "integrity": "sha512-QjTCHU8z/VtihVTHymfNBb6hzcQn/spoRTDt+pCVKPkpBhZ9KzN9dxMvNjFQbbpH5ZFKkvI73lrIilP/OKtrZg==",
+      "version": "1.6.1-0",
+      "resolved": "https://registry.npmjs.org/@saasquatch/component-boilerplate/-/component-boilerplate-1.6.1-0.tgz",
+      "integrity": "sha512-6CLdT9bW2HH9xx7tlQac6YL7GWcG2BnYwXyVUSe/1lAw6d1gHd/Hw4KrNwICJOCror9Uk8O0lGiJ8enpWhFDBw==",
       "requires": {
         "@formatjs/intl": "^1.8.2",
         "@saasquatch/component-environment": "^1.0.4",

--- a/packages/bedrock-components/package.json
+++ b/packages/bedrock-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@saasquatch/bedrock-components",
   "title": "Bedrock Components",
-  "version": "1.4.1-0",
+  "version": "1.4.1",
   "description": "Component library that adds advanced logic to your widgets and pages. Built and maintained by Saasquatch.",
   "icon": "https://res.cloudinary.com/saasquatch/image/upload/v1652219900/squatch-assets/For_Bedrock.svg",
   "main": "dist/index.cjs.js",
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@raisins/stencil-docs-target": "^1.0.0",
-    "@saasquatch/component-boilerplate": "^1.6.1-0",
+    "@saasquatch/component-boilerplate": "^1.6.1",
     "@saasquatch/stencil-hooks": "^2.0.2",
     "@saasquatch/stencilbook": "^1.0.0",
     "@saasquatch/universal-hooks": "^1.0.0",

--- a/packages/bedrock-components/package.json
+++ b/packages/bedrock-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@saasquatch/bedrock-components",
   "title": "Bedrock Components",
-  "version": "1.4.0",
+  "version": "1.4.1-0",
   "description": "Component library that adds advanced logic to your widgets and pages. Built and maintained by Saasquatch.",
   "icon": "https://res.cloudinary.com/saasquatch/image/upload/v1652219900/squatch-assets/For_Bedrock.svg",
   "main": "dist/index.cjs.js",
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@raisins/stencil-docs-target": "^1.0.0",
-    "@saasquatch/component-boilerplate": "^1.6.0",
+    "@saasquatch/component-boilerplate": "^1.6.1-0",
     "@saasquatch/stencil-hooks": "^2.0.2",
     "@saasquatch/stencilbook": "^1.0.0",
     "@saasquatch/universal-hooks": "^1.0.0",

--- a/packages/component-boilerplate/CHANGELOG.md
+++ b/packages/component-boilerplate/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2023-02-06
+
+### Added
+
+- Fires `sq:user-registration` event in `useAuthenticateManagedIdentityWithInstantAccess` hook upon successful registration when in `SquatchJS2` environment
+
 ## [1.6.0] - 2023-01-08
 
 ### Added

--- a/packages/component-boilerplate/package-lock.json
+++ b/packages/component-boilerplate/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saasquatch/component-boilerplate",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saasquatch/component-boilerplate",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "@formatjs/intl": "^1.8.2",

--- a/packages/component-boilerplate/package.json
+++ b/packages/component-boilerplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/component-boilerplate",
-  "version": "1.6.1-0",
+  "version": "1.6.1",
   "private": false,
   "description": "Boilerplate for writing web components for the SaaSquatch widget environments",
   "source": "src/index.ts",

--- a/packages/component-boilerplate/package.json
+++ b/packages/component-boilerplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/component-boilerplate",
-  "version": "1.6.0",
+  "version": "1.6.1-0",
   "private": false,
   "description": "Boilerplate for writing web components for the SaaSquatch widget environments",
   "source": "src/index.ts",

--- a/packages/component-boilerplate/src/hooks/instantaccess/useAuthenticateManagedIdentityWithInstantAccess.ts
+++ b/packages/component-boilerplate/src/hooks/instantaccess/useAuthenticateManagedIdentityWithInstantAccess.ts
@@ -1,7 +1,7 @@
 import {
   getAppDomain,
+  getEnvironment,
   getTenantAlias,
-  getUserIdentity,
   setUserIdentity,
 } from "@saasquatch/component-environment";
 import gql from "graphql-tag";
@@ -118,6 +118,7 @@ export function useAuthenticateManagedIdentityWithInstantAccess(): [
   BaseQueryData<AuthenticateManagedIdentityWithInstantAccessResult>
 ] {
   const programId = useProgramId();
+  const env = getEnvironment();
 
   const [request, { loading, data, errors }] =
     useMutation<AuthenticateManagedIdentityWithInstantAccessResult>(
@@ -147,6 +148,19 @@ export function useAuthenticateManagedIdentityWithInstantAccess(): [
           id: email,
           accountId: email,
         });
+
+        // If in squatch-js, fire a sq:user-registered event
+        if (env === "SquatchJS2") {
+          const event = new CustomEvent("sq:user-registration", {
+            bubbles: true,
+            detail: {
+              userId: email,
+              accountId: email,
+            },
+          });
+
+          document.dispatchEvent(event);
+        }
       } else {
         throw {
           name: "fraud_error",

--- a/packages/mint-components/CHANGELOG.md
+++ b/packages/mint-components/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.3] - 2024-02-06
+
+### Updated
+
+- `@saasquatch/component-boilerplate` package bump
+
 ## [1.7.2] - 2023-01-12
 
 ### Fixed

--- a/packages/mint-components/package-lock.json
+++ b/packages/mint-components/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@saasquatch/mint-components",
-  "version": "1.7.3-0",
+  "version": "1.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saasquatch/mint-components",
-      "version": "1.7.3-0",
+      "version": "1.7.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@raisins/stencil-docs-target": "^1.0.0",
-        "@saasquatch/component-boilerplate": "^1.6.1-0",
+        "@saasquatch/component-boilerplate": "^1.6.1",
         "@saasquatch/shoelace": "^1.0.0",
         "@saasquatch/stencil-hooks": "^2.0.2",
         "@saasquatch/stencilbook": "^1.1.0",
@@ -2805,9 +2805,9 @@
       }
     },
     "node_modules/@saasquatch/component-boilerplate": {
-      "version": "1.6.1-0",
-      "resolved": "https://registry.npmjs.org/@saasquatch/component-boilerplate/-/component-boilerplate-1.6.1-0.tgz",
-      "integrity": "sha512-6CLdT9bW2HH9xx7tlQac6YL7GWcG2BnYwXyVUSe/1lAw6d1gHd/Hw4KrNwICJOCror9Uk8O0lGiJ8enpWhFDBw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@saasquatch/component-boilerplate/-/component-boilerplate-1.6.1.tgz",
+      "integrity": "sha512-jDs1/atMhl1K3RbGQixeluFR85WmoheLdBEs4yAFDgtQaqjljSJbtdz54BUPwkIHEQfs1vzUy63CaxGPXUYJoQ==",
       "dependencies": {
         "@formatjs/intl": "^1.8.2",
         "@saasquatch/component-environment": "^1.0.4",
@@ -17406,9 +17406,9 @@
       }
     },
     "@saasquatch/component-boilerplate": {
-      "version": "1.6.1-0",
-      "resolved": "https://registry.npmjs.org/@saasquatch/component-boilerplate/-/component-boilerplate-1.6.1-0.tgz",
-      "integrity": "sha512-6CLdT9bW2HH9xx7tlQac6YL7GWcG2BnYwXyVUSe/1lAw6d1gHd/Hw4KrNwICJOCror9Uk8O0lGiJ8enpWhFDBw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@saasquatch/component-boilerplate/-/component-boilerplate-1.6.1.tgz",
+      "integrity": "sha512-jDs1/atMhl1K3RbGQixeluFR85WmoheLdBEs4yAFDgtQaqjljSJbtdz54BUPwkIHEQfs1vzUy63CaxGPXUYJoQ==",
       "requires": {
         "@formatjs/intl": "^1.8.2",
         "@saasquatch/component-environment": "^1.0.4",

--- a/packages/mint-components/package-lock.json
+++ b/packages/mint-components/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@saasquatch/mint-components",
-  "version": "1.7.2",
+  "version": "1.7.3-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saasquatch/mint-components",
-      "version": "1.7.2",
+      "version": "1.7.3-0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@raisins/stencil-docs-target": "^1.0.0",
-        "@saasquatch/component-boilerplate": "^1.6.0",
+        "@saasquatch/component-boilerplate": "^1.6.1-0",
         "@saasquatch/shoelace": "^1.0.0",
         "@saasquatch/stencil-hooks": "^2.0.2",
         "@saasquatch/stencilbook": "^1.1.0",
@@ -2805,9 +2805,9 @@
       }
     },
     "node_modules/@saasquatch/component-boilerplate": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@saasquatch/component-boilerplate/-/component-boilerplate-1.6.0.tgz",
-      "integrity": "sha512-QjTCHU8z/VtihVTHymfNBb6hzcQn/spoRTDt+pCVKPkpBhZ9KzN9dxMvNjFQbbpH5ZFKkvI73lrIilP/OKtrZg==",
+      "version": "1.6.1-0",
+      "resolved": "https://registry.npmjs.org/@saasquatch/component-boilerplate/-/component-boilerplate-1.6.1-0.tgz",
+      "integrity": "sha512-6CLdT9bW2HH9xx7tlQac6YL7GWcG2BnYwXyVUSe/1lAw6d1gHd/Hw4KrNwICJOCror9Uk8O0lGiJ8enpWhFDBw==",
       "dependencies": {
         "@formatjs/intl": "^1.8.2",
         "@saasquatch/component-environment": "^1.0.4",
@@ -17406,9 +17406,9 @@
       }
     },
     "@saasquatch/component-boilerplate": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@saasquatch/component-boilerplate/-/component-boilerplate-1.6.0.tgz",
-      "integrity": "sha512-QjTCHU8z/VtihVTHymfNBb6hzcQn/spoRTDt+pCVKPkpBhZ9KzN9dxMvNjFQbbpH5ZFKkvI73lrIilP/OKtrZg==",
+      "version": "1.6.1-0",
+      "resolved": "https://registry.npmjs.org/@saasquatch/component-boilerplate/-/component-boilerplate-1.6.1-0.tgz",
+      "integrity": "sha512-6CLdT9bW2HH9xx7tlQac6YL7GWcG2BnYwXyVUSe/1lAw6d1gHd/Hw4KrNwICJOCror9Uk8O0lGiJ8enpWhFDBw==",
       "requires": {
         "@formatjs/intl": "^1.8.2",
         "@saasquatch/component-environment": "^1.0.4",

--- a/packages/mint-components/package.json
+++ b/packages/mint-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@saasquatch/mint-components",
   "title": "Mint Components",
-  "version": "1.7.2",
+  "version": "1.7.4-0",
   "description": "A minimal design library with components for referral and loyalty experiences. Built with Shoelace components by Saasquatch.",
   "icon": "https://res.cloudinary.com/saasquatch/image/upload/v1652219900/squatch-assets/For_Mint.svg",
   "raisins": "docs/raisins.json",
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@raisins/stencil-docs-target": "^1.0.0",
-    "@saasquatch/component-boilerplate": "^1.6.0",
+    "@saasquatch/component-boilerplate": "^1.6.1-0",
     "@saasquatch/stencil-hooks": "^2.0.2",
     "@saasquatch/stencilbook": "^1.1.0",
     "@saasquatch/universal-hooks": "^1.0.0",

--- a/packages/mint-components/package.json
+++ b/packages/mint-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@saasquatch/mint-components",
   "title": "Mint Components",
-  "version": "1.7.4",
+  "version": "1.7.3",
   "description": "A minimal design library with components for referral and loyalty experiences. Built with Shoelace components by Saasquatch.",
   "icon": "https://res.cloudinary.com/saasquatch/image/upload/v1652219900/squatch-assets/For_Mint.svg",
   "raisins": "docs/raisins.json",

--- a/packages/mint-components/package.json
+++ b/packages/mint-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@saasquatch/mint-components",
   "title": "Mint Components",
-  "version": "1.7.4-0",
+  "version": "1.7.4",
   "description": "A minimal design library with components for referral and loyalty experiences. Built with Shoelace components by Saasquatch.",
   "icon": "https://res.cloudinary.com/saasquatch/image/upload/v1652219900/squatch-assets/For_Mint.svg",
   "raisins": "docs/raisins.json",
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@raisins/stencil-docs-target": "^1.0.0",
-    "@saasquatch/component-boilerplate": "^1.6.1-0",
+    "@saasquatch/component-boilerplate": "^1.6.1",
     "@saasquatch/stencil-hooks": "^2.0.2",
     "@saasquatch/stencilbook": "^1.1.0",
     "@saasquatch/universal-hooks": "^1.0.0",

--- a/packages/mint-components/src/components/sqm-instant-access-registration/sqm-instant-access-registration.feature
+++ b/packages/mint-components/src/components/sqm-instant-access-registration/sqm-instant-access-registration.feature
@@ -35,6 +35,30 @@ Feature: Instant access referrer registration
         When the submission is successful
         Then a new user has been upserted to SaaSquatch as an instant access participant
 
+    @minutia
+    Scenario: Successful registration fires a "sq:user-registration" event only when in the SquatchJS2 environment
+        Given a user has entered a valid email
+        And they submit the form
+        When the submission is successful
+        But the environment is <environment>
+        Then a "sq:user-registration" event <mayBe> fired
+        And the event has "bubbles: true"
+        And the event has details
+        """
+        {
+          userId: [registered email],
+          accountId: [registered email]
+        }
+        """
+
+        Examples:
+          | environment    | mayBe  |
+          | SquatchJS2     | is     |
+          | SquatchAndriod | is not |
+          | SquatchAdmin   | is not |
+          | SquatchPortal  | is not |
+          | None           | is not |
+
     @ui
     Scenario: Slotted content can be included
         Given a user a viewing the follow component HTML


### PR DESCRIPTION
## Description of the change

> Added an event dispatch on a successful user registration for instant access widgets. This is consumed by the SquatchJS update to fire a load event once a user exists. SquatchJS PR: https://github.com/saasquatch/squatch-js/pull/60

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

- Jira issue number: (PUT IT HERE)
- Process.st launch checklist: (PUT IT HERE)

## Checklists

### Development

- [ ] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)
- [ ] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist

### Code review

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
