### PR TITLE
[Bug fix] make engagementMedium not required to fix issues in android sdk

### DIFF
--- a/packages/vanilla-components/src/services/WidgetHost.ts
+++ b/packages/vanilla-components/src/services/WidgetHost.ts
@@ -371,7 +371,7 @@ const API = {
               $userId: String!
               $accountId: String!
               $programId: ID
-              $engagementMedium: UserEngagementMedium!
+              $engagementMedium: UserEngagementMedium
             ) {
               user(id: $userId, accountId: $accountId) {
                 shareLink(
@@ -685,7 +685,7 @@ const API = {
       return this.getClient()
         .query({
           query: gql`
-          query($userId: String!, $accountId: String!, $programId: ID, $engagementMedium: UserEngagementMedium!) {
+          query($userId: String!, $accountId: String!, $programId: ID, $engagementMedium: UserEngagementMedium) {
             user(id: $userId, accountId: $accountId) {
               ${mediums[0]}:messageLink(programId: $programId, engagementMedium: $engagementMedium, shareMedium: ${mediums[0]})
               ${mediums[1]}:messageLink(programId: $programId, engagementMedium: $engagementMedium, shareMedium: ${mediums[1]})


### PR DESCRIPTION
## Description of the change

> engagementMedium isn't required in the backend as it defaults to `UNKNOWN`, so the frontend query shouldn't require it either.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

- Jira issue number: (PUT IT HERE)
- Process.st launch checklist: (PUT IT HERE)

## Checklists

### Development

- [ ] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)
- [ ] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist

### Code review

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
