### PR TITLE
Logger package peer dependency fix

### DIFF
--- a/packages/logger/package-lock.json
+++ b/packages/logger/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saasquatch/logger",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@saasquatch/logger",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "16"

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saasquatch/logger",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -34,7 +34,7 @@
   },
   "peerDependencies": {
     "express": "4",
-    "winston": "3"
+    "winston": ">=3.0.0 <3.12"
   },
   "peerDependenciesMeta": {
     "express": {


### PR DESCRIPTION
## Description of the change

Winston 3.12 introduced a breaking change which makes using syslog log
levels with TypeScript impossible:

https://github.com/winstonjs/winston/commit/c3c391122c44e3f0a46758997bfbb83aaea204ab

A fix is currently in progress but it has not been merged yet:

https://github.com/winstonjs/winston/pull/2349

In the meantime, the peer dependency for Winston will be updated to
prevent consumers from installing the incompatible version.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

- Jira issue number: (PUT IT HERE)
- Process.st launch checklist: (PUT IT HERE)

## Checklists

### Development

- [ ] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)
- [ ] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist

### Code review

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
