### PR TITLE
Centralize publishing to publish-package action

### DIFF
--- a/.github/workflows/mint-components-release.yml
+++ b/.github/workflows/mint-components-release.yml
@@ -49,9 +49,18 @@ jobs:
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
           VERSION=$(jq -r '.version' package.json)
-          npm view "@saasquatch/mint-components@$VERSION" version &>/dev/null \
-            && echo "should-publish=false" >> $GITHUB_OUTPUT \
-            || echo "should-publish=true" >> $GITHUB_OUTPUT
+          OUTPUT=$(npm view "@saasquatch/mint-components@$VERSION" version 2>&1) && {
+            echo "should-publish=false" >> $GITHUB_OUTPUT
+            echo "Version $VERSION is already published"
+            exit 0
+          }
+          if echo "$OUTPUT" | grep -q "E404"; then
+            echo "should-publish=true" >> $GITHUB_OUTPUT
+            echo "Version $VERSION not found on npm, publishing"
+          else
+            echo "::error::npm view failed unexpectedly: $OUTPUT"
+            exit 1
+          fi
 
   publish:
     needs: version

--- a/.github/workflows/mint-components-release.yml
+++ b/.github/workflows/mint-components-release.yml
@@ -13,9 +13,11 @@ permissions:
   issues: read
 
 jobs:
-  release:
+  version:
     runs-on: ubuntu-latest
-    name: Release Mint Components
+    name: Version Mint Components
+    outputs:
+      should-publish: ${{ steps.check-publish.outputs.should-publish }}
     defaults:
       run:
         working-directory: packages/mint-components
@@ -32,24 +34,59 @@ jobs:
       - name: Install packages
         run: npm ci
 
-      - name: Create release pull request or publish to npm
+      - name: Create release pull request
         id: changesets
         uses: changesets/action@001cd79f0a536e733315164543a727bdf2d70aff # 001cd = v1.5.1
         with:
           cwd: packages/mint-components
           version: npm run version
-          publish: npm run release
           title: "mint-components - Version Packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
+
+      - name: Check if version needs publishing
+        id: check-publish
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          npm view "@saasquatch/mint-components@$VERSION" version &>/dev/null \
+            && echo "should-publish=false" >> $GITHUB_OUTPUT \
+            || echo "should-publish=true" >> $GITHUB_OUTPUT
+
+  publish:
+    needs: version
+    if: needs.version.outputs.should-publish == 'true'
+    uses: ./.github/workflows/publish-package.yml
+    with:
+      package: mint-components
+      npm-tag: latest
+    permissions:
+      contents: write
+      id-token: write
+
+  deploy-docs:
+    needs: publish
+    runs-on: ubuntu-latest
+    name: Deploy Docs
+    defaults:
+      run:
+        working-directory: packages/mint-components
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # de0fa = v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 53b83 = v6.3.0
+        with:
+          node-version: 24
+
+      - name: Install packages
+        run: npm ci
 
       - name: Build docs site
-        if: steps.changesets.outputs.published == 'true'
         run: NODE_ENV=dev npm run build
 
       - name: Authenticate with Google Cloud
-        if: steps.changesets.outputs.published == 'true'
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # 7c6bc = v3
         with:
           token_format: "access_token"
@@ -57,9 +94,7 @@ jobs:
           service_account: "github-static-site-actions@static-site-proxy.iam.gserviceaccount.com"
 
       - name: Setup GCP
-        if: steps.changesets.outputs.published == 'true'
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # aa548 = v3.0.1
 
       - name: Deploy docs to bucket
-        if: steps.changesets.outputs.published == 'true'
         run: gsutil -m rsync -d -r www/ gs://stencilbook_static_saasquatch/mint-components/production/

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -26,6 +26,23 @@ on:
           - minor
           - major
 
+  workflow_call:
+    inputs:
+      package:
+        description: The package to publish
+        required: true
+        type: string
+      increment-type:
+        description: The version number to increment (leave empty to publish current version as-is)
+        required: false
+        type: string
+        default: ""
+      npm-tag:
+        description: The npm dist-tag to publish with
+        required: false
+        type: string
+        default: latest
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -34,9 +51,12 @@ jobs:
       contents: write
       id-token: write
 
+    env:
+      VERSIONING: ${{ inputs.increment-type != '' }}
+
     steps:
       - name: Enforce mint-components prerelease-only policy
-        if: inputs.package == 'mint-components' && inputs.increment-type != 'prerelease'
+        if: github.event_name == 'workflow_dispatch' && inputs.package == 'mint-components' && inputs.increment-type != 'prerelease'
         run: |
           echo "::error::Stable releases of @saasquatch/mint-components must go through the 'Mint Components Release' workflow (Changesets). This workflow only supports 'prerelease' for mint-components."
           exit 1
@@ -45,11 +65,7 @@ jobs:
         id: vars
         run: |
           echo "dir=packages/${{ inputs.package }}" >> ${GITHUB_OUTPUT}
-          if [ "${{ inputs.increment-type }}" = "prerelease" ]; then
-            echo "npmtag=next" >> ${GITHUB_OUTPUT}
-          else
-            echo "npmtag=latest" >> ${GITHUB_OUTPUT}
-          fi
+          echo "npmtag=${{ inputs.npm-tag || (inputs.increment-type == 'prerelease' && 'next') || 'latest' }}" >> ${GITHUB_OUTPUT}
 
       - name: Checkout
         id: checkout
@@ -65,6 +81,7 @@ jobs:
       # we could add this to devDependencies but we'd have to do it for every package
       # so might as well just install it inside the action
       - name: Install semver
+        if: env.VERSIONING == 'true'
         id: npm-i-semver
         run: |
           npm i --no-save semver
@@ -75,6 +92,7 @@ jobs:
         run: npm ci
 
       - name: Compute new version
+        if: env.VERSIONING == 'true'
         id: compute-version
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # ed597 = v8
         with:
@@ -115,6 +133,7 @@ jobs:
             return newVersion;
 
       - name: Extract package name
+        if: env.VERSIONING == 'true'
         id: extract-package-name
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # ed597 = v8
         with:
@@ -135,6 +154,7 @@ jobs:
             return packageName;
 
       - name: Write new version to file
+        if: env.VERSIONING == 'true'
         working-directory: ${{ steps.vars.outputs.dir }}
         run: |
           jq '.version = "${{ steps.compute-version.outputs.result }}"' package.json > package.json.tmp
@@ -151,6 +171,7 @@ jobs:
         run: npm publish --provenance --access public --tag ${{ steps.vars.outputs.npmtag }}
 
       - name: Commit and push changes
+        if: env.VERSIONING == 'true'
         id: commit-and-push
         uses: saasquatch/git-commit-action@v0.0.15
         env:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -29,14 +29,9 @@ on:
   workflow_call:
     inputs:
       package:
-        description: The package to publish
+        description: "The package to publish (must be one of: express-boilerplate, integration-boilerplate-node, logger, mint-components, program-boilerplate, program-test-suite, publish-helper)"
         required: true
         type: string
-      increment-type:
-        description: The version number to increment (leave empty to publish current version as-is)
-        required: false
-        type: string
-        default: ""
       npm-tag:
         description: The npm dist-tag to publish with
         required: false
@@ -52,7 +47,7 @@ jobs:
       id-token: write
 
     env:
-      VERSIONING: ${{ inputs.increment-type != '' }}
+      VERSIONING: ${{ github.event_name == 'workflow_dispatch' }}
 
     steps:
       - name: Enforce mint-components prerelease-only policy

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -56,6 +56,13 @@ jobs:
           echo "::error::Stable releases of @saasquatch/mint-components must go through the 'Mint Components Release' workflow (Changesets). This workflow only supports 'prerelease' for mint-components."
           exit 1
 
+      - name: Validate package input
+        run: |
+          case "${{ inputs.package }}" in
+            express-boilerplate|integration-boilerplate-node|logger|mint-components|program-boilerplate|program-test-suite|publish-helper) ;;
+            *) echo "::error::Invalid package '${{ inputs.package }}'."; exit 1 ;;
+          esac
+
       - name: Generate Variables
         id: vars
         run: |

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -57,17 +57,27 @@ jobs:
           exit 1
 
       - name: Validate package input
+        env:
+          PACKAGE: ${{ inputs.package }}
         run: |
-          case "${{ inputs.package }}" in
+          case "$PACKAGE" in
             express-boilerplate|integration-boilerplate-node|logger|mint-components|program-boilerplate|program-test-suite|publish-helper) ;;
-            *) echo "::error::Invalid package '${{ inputs.package }}'."; exit 1 ;;
+            *) echo "::error::Invalid package '${PACKAGE}'."; exit 1 ;;
           esac
 
       - name: Generate Variables
         id: vars
+        env:
+          PACKAGE: ${{ inputs.package }}
+          NPM_TAG: ${{ inputs.npm-tag || (inputs.increment-type == 'prerelease' && 'next') || 'latest' }}
         run: |
-          echo "dir=packages/${{ inputs.package }}" >> ${GITHUB_OUTPUT}
-          echo "npmtag=${{ inputs.npm-tag || (inputs.increment-type == 'prerelease' && 'next') || 'latest' }}" >> ${GITHUB_OUTPUT}
+          # Validate npm-tag is a safe dist-tag value (alphanumeric, hyphens, dots)
+          if [[ ! "$NPM_TAG" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+            echo "::error::Invalid npm-tag '${NPM_TAG}'. Must be alphanumeric with hyphens/dots only."
+            exit 1
+          fi
+          echo "dir=packages/${PACKAGE}" >> ${GITHUB_OUTPUT}
+          echo "npmtag=${NPM_TAG}" >> ${GITHUB_OUTPUT}
 
       - name: Checkout
         id: checkout

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -84,7 +84,7 @@ jobs:
         if: env.VERSIONING == 'true'
         id: npm-i-semver
         run: |
-          npm i --no-save semver
+          npm i --no-save semver@7.8.0
 
       - name: Install dependencies
         id: npm-ci

--- a/packages/mint-components/package.json
+++ b/packages/mint-components/package.json
@@ -43,7 +43,7 @@
     "changeset": "changeset",
     "version": "changeset version && npm install",
     "release": "changeset publish",
-    "prepublishOnly": "if [ \"$CI\" != \"true\" ]; then echo Error: Direct npm publish is disabled for @saasquatch/mint-components. Publish via the Mint Components Release (stable) or Publish Package (prerelease) GitHub Actions workflow. && exit 1; fi"
+    "prepublishOnly": "if [ \"$CI\" != \"true\" ]; then echo 'Error: Direct npm publish is disabled for @saasquatch/mint-components. Publish via the Mint Components Release (stable) or Publish Package (prerelease) GitHub Actions workflow.' && exit 1; fi"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.2",


### PR DESCRIPTION
## Description of the change

NPMJS only allows us to declare one trusted action for publishing

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

- Jira issue number: (PUT IT HERE)
- Process.st launch checklist: (PUT IT HERE)

## Checklists

### Development

- [ ] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)
- [ ] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist

### Code review

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
