### PR TITLE
Proper consolidation of trusted publishing

### DIFF
--- a/.github/workflows/mint-components-release.yml
+++ b/.github/workflows/mint-components-release.yml
@@ -50,7 +50,6 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
 
   deploy-docs:
-    needs: publish
     runs-on: ubuntu-latest
     name: Deploy Docs
 

--- a/.github/workflows/mint-components-release.yml
+++ b/.github/workflows/mint-components-release.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           npm ci --ignore-scripts --allow-git=none
           # allow post-install patching of packages without allowing all other (potentially malicious) scripts
-          npm x patch-packages
+          npm run postinstall --if-present
 
       - name: Create release pull request or publish to npm
         id: changesets

--- a/.github/workflows/mint-components-release.yml
+++ b/.github/workflows/mint-components-release.yml
@@ -1,29 +1,29 @@
 name: Mint Components Release
 on:
-  push:
-    branches: [master]
-    paths:
-      - "packages/mint-components/**"
-  workflow_dispatch:
+  workflow_call:
 
-permissions:
-  id-token: write
-  contents: write
-  pull-requests: write
-  issues: read
+permissions: {}
 
 jobs:
   version:
     runs-on: ubuntu-latest
     name: Version Mint Components
-    outputs:
-      should-publish: ${{ steps.check-publish.outputs.should-publish }}
+
+    permissions:
+      contents: write # Push commits to edit version numbers/changelogs
+      id-token: write # GCP workload identity federation
+      pull-requests: write # Open a PR
+      issues: read # ??
+
     defaults:
       run:
         working-directory: packages/mint-components
+
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # de0fa = v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 53b83 = v6.3.0
@@ -32,57 +32,38 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install packages
-        run: npm ci
+        run: npm ci --ignore-scripts --allow-git=none
 
-      - name: Create release pull request
+      - name: Create release pull request or publish to npm
         id: changesets
         uses: changesets/action@001cd79f0a536e733315164543a727bdf2d70aff # 001cd = v1.5.1
         with:
           cwd: packages/mint-components
           version: npm run version
+          publish: npm run release
           title: "mint-components - Version Packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check if version needs publishing
-        id: check-publish
-        if: steps.changesets.outputs.hasChangesets == 'false'
-        run: |
-          VERSION=$(jq -r '.version' package.json)
-          OUTPUT=$(npm view "@saasquatch/mint-components@$VERSION" version 2>&1) && {
-            echo "should-publish=false" >> $GITHUB_OUTPUT
-            echo "Version $VERSION is already published"
-            exit 0
-          }
-          if echo "$OUTPUT" | grep -q "E404"; then
-            echo "should-publish=true" >> $GITHUB_OUTPUT
-            echo "Version $VERSION not found on npm, publishing"
-          else
-            echo "::error::npm view failed unexpectedly: $OUTPUT"
-            exit 1
-          fi
-
-  publish:
-    needs: version
-    if: needs.version.outputs.should-publish == 'true'
-    uses: ./.github/workflows/publish-package.yml
-    with:
-      package: mint-components
-      npm-tag: latest
-    permissions:
-      contents: write
-      id-token: write
+          NPM_CONFIG_PROVENANCE: true
 
   deploy-docs:
     needs: publish
     runs-on: ubuntu-latest
     name: Deploy Docs
+
+    permissions:
+      contents: read
+      id-token: write # GCP workload identity federation
+
     defaults:
       run:
         working-directory: packages/mint-components
+
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # de0fa = v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 53b83 = v6.3.0
@@ -90,7 +71,7 @@ jobs:
           node-version: 24
 
       - name: Install packages
-        run: npm ci
+        run: npm ci --ignore-scripts --allow-git=none
 
       - name: Build docs site
         run: NODE_ENV=dev npm run build

--- a/.github/workflows/mint-components-release.yml
+++ b/.github/workflows/mint-components-release.yml
@@ -32,7 +32,10 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install packages
-        run: npm ci --ignore-scripts --allow-git=none
+        run: |
+          npm ci --ignore-scripts --allow-git=none
+          # allow post-install patching of packages without allowing all other (potentially malicious) scripts
+          npm x patch-packages
 
       - name: Create release pull request or publish to npm
         id: changesets
@@ -70,11 +73,12 @@ jobs:
         with:
           node-version: 24
 
-      - name: Install packages
-        run: npm ci --ignore-scripts --allow-git=none
-
       - name: Build docs site
-        run: NODE_ENV=dev npm run build
+        run: |
+          npm ci --ignore-scripts --allow-git=none
+          # allow post-install patching of packages without allowing all other (potentially malicious) scripts
+          npm x patch-packages
+          NODE_ENV=dev npm run build
 
       - name: Authenticate with Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # 7c6bc = v3

--- a/.github/workflows/mint-components-release.yml
+++ b/.github/workflows/mint-components-release.yml
@@ -13,7 +13,6 @@ jobs:
       contents: write # Push commits to edit version numbers/changelogs
       id-token: write # GCP workload identity federation
       pull-requests: write # Open a PR
-      issues: read # ??
 
     defaults:
       run:

--- a/.github/workflows/mint-components-release.yml
+++ b/.github/workflows/mint-components-release.yml
@@ -48,37 +48,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
-  deploy-docs:
-    runs-on: ubuntu-latest
-    name: Deploy Docs
-
-    permissions:
-      contents: read
-      id-token: write # GCP workload identity federation
-
-    defaults:
-      run:
-        working-directory: packages/mint-components
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # de0fa = v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 53b83 = v6.3.0
-        with:
-          node-version: 24
-
       - name: Build docs site
-        run: |
-          npm ci --ignore-scripts --allow-git=none
-          # allow post-install patching of packages without allowing all other (potentially malicious) scripts
-          npm x patch-packages
-          NODE_ENV=dev npm run build
+        if: steps.changesets.outputs.published == 'true'
+        run: NODE_ENV=dev npm run build
 
       - name: Authenticate with Google Cloud
+        if: steps.changesets.outputs.published == 'true'
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # 7c6bc = v3
         with:
           token_format: "access_token"
@@ -86,7 +61,9 @@ jobs:
           service_account: "github-static-site-actions@static-site-proxy.iam.gserviceaccount.com"
 
       - name: Setup GCP
+        if: steps.changesets.outputs.published == 'true'
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # aa548 = v3.0.1
 
       - name: Deploy docs to bucket
+        if: steps.changesets.outputs.published == 'true'
         run: gsutil -m rsync -d -r www/ gs://stencilbook_static_saasquatch/mint-components/production/

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,42 +1,19 @@
 name: Publish Package
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       package:
         description: The package to publish
         required: true
-        type: choice
-        options:
-          - express-boilerplate
-          - integration-boilerplate-node
-          - logger
-          - mint-components
-          - program-boilerplate
-          - program-test-suite
-          - publish-helper
+        # type: choice isn't supported by workflow_call
+        type: string
 
       increment-type:
-        description: The version number to increment
+        description: The version number to increment (prerelease, patch, minor, or major)
         required: true
-        type: choice
-        options:
-          - prerelease
-          - patch
-          - minor
-          - major
-
-  workflow_call:
-    inputs:
-      package:
-        description: "The package to publish (must be one of: express-boilerplate, integration-boilerplate-node, logger, mint-components, program-boilerplate, program-test-suite, publish-helper)"
-        required: true
+        # type: choice isn't supported by workflow_call
         type: string
-      npm-tag:
-        description: The npm dist-tag to publish with
-        required: false
-        type: string
-        default: latest
 
 jobs:
   publish:
@@ -47,41 +24,24 @@ jobs:
       id-token: write
 
     env:
-      VERSIONING: ${{ github.event_name == 'workflow_dispatch' }}
+      PACKAGE: ${{ inputs.package }}
+      INCREMENT_TYPE: ${{ inputs.increment-type }}
+      VERSIONING: ${{ inputs.package != 'mint-components' }}
+      NPM_TAG: ${{ (inputs.increment-type == 'prerelease' && 'next') || 'latest' }}
+      WORKING_DIR: packages/${{ inputs.package }}
 
     steps:
       - name: Enforce mint-components prerelease-only policy
-        if: github.event_name == 'workflow_dispatch' && inputs.package == 'mint-components' && inputs.increment-type != 'prerelease'
+        if: inputs.package == 'mint-components' && inputs.increment-type != 'prerelease'
         run: |
           echo "::error::Stable releases of @saasquatch/mint-components must go through the 'Mint Components Release' workflow (Changesets). This workflow only supports 'prerelease' for mint-components."
           exit 1
 
-      - name: Validate package input
-        env:
-          PACKAGE: ${{ inputs.package }}
-        run: |
-          case "$PACKAGE" in
-            express-boilerplate|integration-boilerplate-node|logger|mint-components|program-boilerplate|program-test-suite|publish-helper) ;;
-            *) echo "::error::Invalid package '${PACKAGE}'."; exit 1 ;;
-          esac
-
-      - name: Generate Variables
-        id: vars
-        env:
-          PACKAGE: ${{ inputs.package }}
-          NPM_TAG: ${{ inputs.npm-tag || (inputs.increment-type == 'prerelease' && 'next') || 'latest' }}
-        run: |
-          # Validate npm-tag is a safe dist-tag value (alphanumeric, hyphens, dots)
-          if [[ ! "$NPM_TAG" =~ ^[a-zA-Z0-9._-]+$ ]]; then
-            echo "::error::Invalid npm-tag '${NPM_TAG}'. Must be alphanumeric with hyphens/dots only."
-            exit 1
-          fi
-          echo "dir=packages/${PACKAGE}" >> ${GITHUB_OUTPUT}
-          echo "npmtag=${NPM_TAG}" >> ${GITHUB_OUTPUT}
-
       - name: Checkout
         id: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # de0fa = v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup NodeJS
         id: setup-node
@@ -100,7 +60,7 @@ jobs:
 
       - name: Install dependencies
         id: npm-ci
-        working-directory: ${{ steps.vars.outputs.dir }}
+        working-directory: ${{ env.WORKING_DIR }}
         run: npm ci
 
       - name: Compute new version
@@ -114,7 +74,22 @@ jobs:
             const { readFileSync } = require("fs");
             const { join } = require("path");
 
-            const incrementType = "${{ inputs.increment-type }}";
+            const allowedPackages = [
+              "express-boilerplate",
+              "integration-boilerplate-node",
+              "logger",
+              "mint-components",
+              "program-boilerplate",
+              "program-test-suite",
+              "publish-helper",
+            ];
+
+            const package = process.env.PACKAGE;
+            if (!allowedPackages.includes(package)) {
+              throw new Error(`"${package}" is not in the list of allowed packages.`);
+            }
+
+            const incrementType = process.env.INCREMENT_TYPE;
 
             if (
               !["major", "minor", "patch", "prerelease"].some(
@@ -124,7 +99,7 @@ jobs:
               throw new Error(`Invalid semver increment type "${incrementType}" specified`);
             }
 
-            const workingDir = "${{ steps.vars.outputs.dir }}";
+            const workingDir = process.env.WORKING_DIR;
             const packageJson = JSON.parse(
               readFileSync(join(workingDir, "./package.json"), { encoding: "utf8" }),
             );
@@ -154,7 +129,7 @@ jobs:
             const { readFileSync } = require("fs");
             const { join } = require("path");
 
-            const workingDir = "${{ steps.vars.outputs.dir }}";
+            const workingDir = process.env.WORKING_DIR;
             const packageJson = JSON.parse(
               readFileSync(join(workingDir, "./package.json"), { encoding: "utf8" }),
             );
@@ -167,11 +142,13 @@ jobs:
 
       - name: Write new version to file
         if: env.VERSIONING == 'true'
-        working-directory: ${{ steps.vars.outputs.dir }}
+        working-directory: ${{ env.WORKING_DIR }}
+        env:
+          NEW_VERSION: ${{ steps.compute-version.outputs.result }}
         run: |
-          jq '.version = "${{ steps.compute-version.outputs.result }}"' package.json > package.json.tmp
-          jq '.version = "${{ steps.compute-version.outputs.result }}"' package-lock.json > package-lock.tmp1.json
-          jq '.packages."".version = "${{ steps.compute-version.outputs.result }}"' package-lock.tmp1.json > package-lock.json.tmp
+          jq ".version = \"${NEW_VERSION}\"" package.json > package.json.tmp
+          jq ".version = \"${NEW_VERSION}\"" package-lock.json > package-lock.tmp1.json
+          jq ".packages.\"\".version = \"${NEW_VERSION}\"" package-lock.tmp1.json > package-lock.json.tmp
 
           mv package.json.tmp package.json
           mv package-lock.json.tmp package-lock.json
@@ -179,8 +156,8 @@ jobs:
       # Package will be built during this step thanks to the `prepack` lifecycle script
       - name: NPM Publish
         id: publish
-        working-directory: ${{ steps.vars.outputs.dir }}
-        run: npm publish --provenance --access public --tag ${{ steps.vars.outputs.npmtag }}
+        working-directory: ${{ env.WORKING_DIR }}
+        run: npm publish --provenance --access public --tag "${NPM_TAG}"
 
       - name: Commit and push changes
         if: env.VERSIONING == 'true'
@@ -189,7 +166,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          working-directory: ${{ steps.vars.outputs.dir }}
+          working-directory: ${{ env.WORKING_DIR }}
           files: |
             package.json
             package-lock.json

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -56,11 +56,6 @@ jobs:
         run: |
           npm i --no-save semver@7.8.0
 
-      - name: Install dependencies
-        id: npm-ci
-        working-directory: ${{ env.WORKING_DIR }}
-        run: npm ci
-
       - name: Compute new version
         id: compute-version
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # ed597 = v8
@@ -68,8 +63,8 @@ jobs:
           result-encoding: string
           script: |
             const semver = require("semver");
-            const { readFileSync } = require("fs");
-            const { join } = require("path");
+            const { readFileSync } = require("node:fs");
+            const { join } = require("node:path");
 
             const allowedPackages = [
               "express-boilerplate",
@@ -122,8 +117,8 @@ jobs:
         with:
           result-encoding: string
           script: |
-            const { readFileSync } = require("fs");
-            const { join } = require("path");
+            const { readFileSync } = require("node:fs");
+            const { join } = require("node:path");
 
             const workingDir = process.env.WORKING_DIR;
             const packageJson = JSON.parse(
@@ -135,6 +130,11 @@ jobs:
               throw new Error("Failed to extract package name from package.json");
             }
             return packageName;
+
+      - name: Install dependencies
+        id: npm-ci
+        working-directory: ${{ env.WORKING_DIR }}
+        run: npm ci --ignore-scripts --allow-git=none
 
       - name: Write new version to file
         working-directory: ${{ env.WORKING_DIR }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -15,13 +15,16 @@ on:
         # type: choice isn't supported by workflow_call
         type: string
 
+permissions: {}
+
 jobs:
   publish:
+    name: "Publish package"
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
-      id-token: write
+      contents: write # Create commit & tag for edited version number in package.json etc
+      id-token: write # GCP workload identity federation
 
     env:
       PACKAGE: ${{ inputs.package }}
@@ -76,18 +79,20 @@ jobs:
               "publish-helper",
             ];
 
+            const allowedIncrementTypes = [
+              "major",
+              "minor",
+              "patch",
+              "prerelease",
+            ];
+
             const package = process.env.PACKAGE;
             if (!allowedPackages.includes(package)) {
-              throw new Error(`"${package}" is not in the list of allowed packages.`);
+              throw new Error(`"${package}" is not in the list of allowed packages`);
             }
 
             const incrementType = process.env.INCREMENT_TYPE;
-
-            if (
-              !["major", "minor", "patch", "prerelease"].some(
-                (kind) => incrementType === kind,
-              )
-            ) {
+            if (!allowedIncrementTypes.includes(incrementType)) {
               throw new Error(`Invalid semver increment type "${incrementType}" specified`);
             }
 
@@ -111,6 +116,7 @@ jobs:
 
             return newVersion;
 
+      # This can't be combined with the previous step because each one can only have one output
       - name: Extract package name
         id: extract-package-name
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # ed597 = v8

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -26,7 +26,6 @@ jobs:
     env:
       PACKAGE: ${{ inputs.package }}
       INCREMENT_TYPE: ${{ inputs.increment-type }}
-      VERSIONING: ${{ inputs.package != 'mint-components' }}
       NPM_TAG: ${{ (inputs.increment-type == 'prerelease' && 'next') || 'latest' }}
       WORKING_DIR: packages/${{ inputs.package }}
 
@@ -53,7 +52,6 @@ jobs:
       # we could add this to devDependencies but we'd have to do it for every package
       # so might as well just install it inside the action
       - name: Install semver
-        if: env.VERSIONING == 'true'
         id: npm-i-semver
         run: |
           npm i --no-save semver@7.8.0
@@ -64,7 +62,6 @@ jobs:
         run: npm ci
 
       - name: Compute new version
-        if: env.VERSIONING == 'true'
         id: compute-version
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # ed597 = v8
         with:
@@ -120,7 +117,6 @@ jobs:
             return newVersion;
 
       - name: Extract package name
-        if: env.VERSIONING == 'true'
         id: extract-package-name
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # ed597 = v8
         with:
@@ -141,7 +137,6 @@ jobs:
             return packageName;
 
       - name: Write new version to file
-        if: env.VERSIONING == 'true'
         working-directory: ${{ env.WORKING_DIR }}
         env:
           NEW_VERSION: ${{ steps.compute-version.outputs.result }}
@@ -160,7 +155,6 @@ jobs:
         run: npm publish --provenance --access public --tag "${NPM_TAG}"
 
       - name: Commit and push changes
-        if: env.VERSIONING == 'true'
         id: commit-and-push
         uses: saasquatch/git-commit-action@v0.0.15
         env:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -86,9 +86,9 @@ jobs:
               "prerelease",
             ];
 
-            const package = process.env.PACKAGE;
-            if (!allowedPackages.includes(package)) {
-              throw new Error(`"${package}" is not in the list of allowed packages`);
+            const pkg = process.env.PACKAGE;
+            if (!allowedPackages.includes(pkg)) {
+              throw new Error(`"${pkg}" is not in the list of allowed packages`);
             }
 
             const incrementType = process.env.INCREMENT_TYPE;

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -140,7 +140,10 @@ jobs:
       - name: Install dependencies
         id: npm-ci
         working-directory: ${{ env.WORKING_DIR }}
-        run: npm ci --ignore-scripts --allow-git=none
+        run: |
+          npm ci --ignore-scripts --allow-git=none
+          # Allow our own postinstall scripts but not for all packages
+          npm run postinstall --if-present
 
       - name: Write new version to file
         working-directory: ${{ env.WORKING_DIR }}

--- a/.github/workflows/trusted-publish.yml
+++ b/.github/workflows/trusted-publish.yml
@@ -34,7 +34,7 @@ permissions: {}
 
 jobs:
   publish-package:
-    if: github.event_name == 'workflow_dispatch' && !(inputs.package == 'mint-components' && inputs.increment-type != 'prerelease')
+    if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/publish-package.yml
     with:
       package: ${{ inputs.package }}

--- a/.github/workflows/trusted-publish.yml
+++ b/.github/workflows/trusted-publish.yml
@@ -40,8 +40,8 @@ jobs:
       package: ${{ inputs.package }}
       increment-type: ${{ inputs.increment-type }}
     permissions:
-      contents: write
-      id-token: write
+      contents: write # Create commit & tag for edited version number in package.json etc
+      id-token: write # GCP workload identity federation
 
   mint-components-release:
     if: github.event_name == 'push'
@@ -50,4 +50,3 @@ jobs:
       contents: write # Push commits to edit version numbers/changelogs
       id-token: write # GCP workload identity federation
       pull-requests: write # Open a PR
-      issues: read # ??

--- a/.github/workflows/trusted-publish.yml
+++ b/.github/workflows/trusted-publish.yml
@@ -1,0 +1,53 @@
+name: Trusted Publisher Workflow
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "packages/mint-components/**"
+  workflow_dispatch:
+    inputs:
+      package:
+        description: The package to publish
+        required: true
+        type: choice
+        options:
+          - express-boilerplate
+          - integration-boilerplate-node
+          - logger
+          - mint-components
+          - program-boilerplate
+          - program-test-suite
+          - publish-helper
+
+      increment-type:
+        description: The version number to increment
+        required: true
+        type: choice
+        options:
+          - prerelease
+          - patch
+          - minor
+          - major
+
+permissions: {}
+
+jobs:
+  publish-package:
+    if: github.event_name == 'workflow_dispatch' && !(inputs.package == 'mint-components' && inputs.increment-type != 'prerelease')
+    uses: ./.github/workflows/publish-package.yml
+    with:
+      package: ${{ inputs.package }}
+      increment-type: ${{ inputs.increment-type }}
+    permissions:
+      contents: write
+      id-token: write
+
+  mint-components-release:
+    if: github.event_name == 'push'
+    uses: ./.github/workflows/mint-components-release.yml
+    permissions:
+      contents: write # Push commits to edit version numbers/changelogs
+      id-token: write # GCP workload identity federation
+      pull-requests: write # Open a PR
+      issues: read # ??


### PR DESCRIPTION
## Description of the change

Use one primary workflow that will be the designated trusted publisher and have it delegate to either the `publish-package` workflow or the Mint Changesets workflow.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation or Development tools (readme, specs, tests, code formatting)

## Checklists

### Development

- [x] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)

### Paperwork

- [x] This pull request has a descriptive title and information useful to a reviewer

### Code review

- [x] Security impacts of this change have been considered